### PR TITLE
Fix #15: Full SEO audit of site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,4 +3,45 @@ languageCode = "en-us"
 publishDir = "docs"
 title = "Spicer Matthews Personal Site"
 disableHugoGeneratorInject = true
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["taxonomy", "term"]
+
+# Emit a robots.txt (rendered from layouts/robots.txt) so crawlers find the sitemap.
+enableRobotsTXT = true
+
+# Sitewide SEO defaults. These feed the meta tags, Open Graph, Twitter cards, and
+# JSON-LD structured data rendered in layouts/partials/head.html and schema.html.
+[params]
+  brand = "Spicer Matthews"
+  author = "Spicer Matthews"
+  description = "Spicer Matthews is a software developer, entrepreneur, and options trader in Newberg, Oregon — writing about AI-first development, building products, and options trading."
+  og_image = "/images/spicer-matthews-wine-drinking.jpg"
+  twitter = "spicermatthews"
+  locale = "en_US"
+  keywords = ["Spicer Matthews", "software developer", "options trading", "entrepreneur", "AI-first development", "Claude Code", "Hugo static site", "Newberg Oregon"]
+
+[author]
+  name = "Spicer Matthews"
+
+# Default sitemap hints emitted by Hugo's built-in sitemap.xml.
+[sitemap]
+  changefreq = "weekly"
+  filename = "sitemap.xml"
+  priority = 0.5
+
+# Include every post in the RSS feed (a full feed helps both readers and LLM ingestion).
+[services]
+  [services.rss]
+    limit = -1
+
+# Powers the "Related Posts" section on blog posts (layouts/blog/single.html),
+# matched primarily on shared keywords and recency.
+[related]
+  threshold = 80
+  includeNewer = true
+  toLower = true
+  [[related.indices]]
+    name = "keywords"
+    weight = 100
+  [[related.indices]]
+    name = "date"
+    weight = 10

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,12 @@
+---
+title: "Spicer Matthews — Software Developer & Options Trader"
+description: "Spicer Matthews is a software developer, entrepreneur, and options trader in Newberg, Oregon. I write about AI-first development with Claude Code, building products, and trading options."
+keywords:
+  - "Spicer Matthews"
+  - "software developer"
+  - "options trader"
+  - "entrepreneur"
+  - "AI-first development"
+  - "Claude Code"
+  - "Newberg Oregon"
+---

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Blog"
+description: "Essays by Spicer Matthews on AI-first software development, building products, options trading, and entrepreneurship — lessons from 20+ years of shipping software."
+keywords:
+  - "Spicer Matthews blog"
+  - "AI-first development"
+  - "software development essays"
+  - "options trading"
+  - "building software products"
+  - "indie hacking"
+---

--- a/content/blog/am-over-vendors-that-are-not-transparent-in-pricing.html
+++ b/content/blog/am-over-vendors-that-are-not-transparent-in-pricing.html
@@ -1,8 +1,21 @@
 ---
-title: "Am Over Vendors That Are Not Transparent in Pricing"
+title: "I'm Over Vendors That Aren't Transparent About Pricing"
 date: 2020-04-21T20:18:58-07:00
 draft: false
-description: "The days of secret per customer pricing should be over. Vendors should be transparent with pricing and treat all customers the same."
+description: "I'm done with vendors that hide pricing and reward schmoozing over fairness. Here's why transparent pricing that treats every customer the same wins my business."
+keywords:
+  - "transparent pricing for vendors"
+  - "secret per-customer pricing"
+  - "construction supplier pricing"
+  - "why suppliers charge different prices"
+  - "Home Depot vs local supplier pricing"
+  - "fair pricing for all customers"
+  - "relationship-based pricing in construction"
+  - "building material pricing transparency"
+related:
+  - "how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too"
+  - "why-100-customers-at-200-beats-1000-at-20"
+  - "remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses"
 og_image: "/images/vendor-sales-person.png"
 ---
 

--- a/content/blog/delighting-customers-with-airbnb.html
+++ b/content/blog/delighting-customers-with-airbnb.html
@@ -2,7 +2,20 @@
 title: "Delighting Customers With Airbnb"
 date: 2019-07-30T12:18:58-07:00
 draft: false
-description: "This week, we launched bendmountbachelorvillage.com for really no good reason. For years now, we have been using Airbnb to rent out our vacation rental in Bend, OR."
+description: "Why my wife and I obsess over delighting customers, from our grandfather's NAPA store to our software businesses and Airbnb guests in Bend, Oregon."
+keywords:
+  - "delighting customers"
+  - "how to delight customers"
+  - "delighting Airbnb guests"
+  - "customer experience as a business strategy"
+  - "Airbnb host tips for guests"
+  - "customer retention through delight"
+  - "Bend Oregon vacation rental"
+  - "building customer relationships"
+related:
+  - "why-100-customers-at-200-beats-1000-at-20"
+  - "hello-world-my-new-blog-hugo-tailwind-css-and-more"
+  - "reimagining-real-estate-a-call-for-excellence-over-exclusivity"
 og_image: "/images/condo-rental-in-bend-oregon.png"
 ---
 

--- a/content/blog/full-circle-back-to-the-terminal.html
+++ b/content/blog/full-circle-back-to-the-terminal.html
@@ -2,7 +2,20 @@
 title: "Full Circle: Back to the Terminal"
 date: 2026-02-19T12:00:00-07:00
 draft: false
-description: "I started my career in the late 90s doing everything in the terminal. Over 30 years I migrated to GUIs, web apps, and desktop tools. Now, thanks to Claude Code, Neovim, and tmux, I'm back where I started — and it's never felt better."
+description: "After 30 years in GUIs, I'm back in the terminal full-time with Claude Code, Neovim, and tmux. Here's my development workflow and why it feels like home."
+keywords:
+  - "terminal development workflow"
+  - "Claude Code tmux Neovim"
+  - "Neovim vs VS Code"
+  - "tmux workflow for developers"
+  - "managing dotfiles with GNU Stow"
+  - "LazyVim terminal IDE"
+  - "developer terminal setup 2026"
+  - "living in the terminal"
+related:
+  - "my-new-ai-first-development-workflow-github-issues"
+  - "i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one"
+  - "i-built-a-tradier-cli-because-ai-agents-deserve-better-tools"
 og_image: "/images/blog/full-circle-back-to-the-terminal.jpg"
 ---
 

--- a/content/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more.html
+++ b/content/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more.html
@@ -2,7 +2,19 @@
 title: "Hello World: My New Blog, Hugo, Tailwind CSS, and More"
 date: 2019-07-17T19:02:38-07:00
 draft: false
-description: "Today, I am launching, once again, my personal blog. Starting over. Welcome to the new spicermatthews.com"
+description: "I relaunched my personal blog as a static Hugo site styled with Tailwind CSS and hosted on GitHub Pages. Here's why I ditched the CMS headaches for good."
+keywords:
+  - "building a personal blog with Hugo and Tailwind CSS"
+  - "Hugo static site on GitHub Pages"
+  - "why I switched from a CMS to a static site"
+  - "Tailwind CSS vs Bootstrap"
+  - "Hugo static site generator for developers"
+  - "low-maintenance personal blog"
+  - "design your own site without a designer"
+  - "Craft CMS alternative for personal blogs"
+related:
+  - "using-hugo-with-google-docs"
+  - "full-circle-back-to-the-terminal"
 og_image: "/images/spicer-matthews-wine-drinking.jpg"
 ---
 

--- a/content/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too.html
+++ b/content/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too.html
@@ -2,7 +2,20 @@
 title: "How I Learned to Spot Inflated Bids (and What You Can Do Too)"
 date: 2025-10-15T10:00:00-07:00
 draft: false
-description: "After two decades as a hobbyist builder, I've learned to spot when contractors are pricing the job—or pricing the lifestyle. Here's how to protect your budget and get fair quotes."
+description: "After two decades of building, I learned to spot inflated contractor bids and price-gouging. Here's how I get fair quotes and protect my renovation budget."
+keywords:
+  - "how to spot inflated contractor bids"
+  - "contractor overcharging based on home value"
+  - "how to get fair contractor quotes"
+  - "why are my contractor quotes so high"
+  - "negotiating contractor bids on a renovation"
+  - "contractor sizing up customers"
+  - "getting multiple bids for home projects"
+  - "red flags when hiring a contractor"
+related:
+  - "remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses"
+  - "am-over-vendors-that-are-not-transparent-in-pricing"
+  - "reimagining-real-estate-a-call-for-excellence-over-exclusivity"
 og_image: "/images/construction-home-project.png"
 ---
 

--- a/content/blog/i-built-a-personal-ai-assistant-that-lives-in-slack.html
+++ b/content/blog/i-built-a-personal-ai-assistant-that-lives-in-slack.html
@@ -2,7 +2,20 @@
 title: "I Built a Personal AI Assistant That Lives in Slack"
 date: 2026-01-30T10:00:00-07:00
 draft: false
-description: "Inspired by OpenClaw, I built Autumn — a personal AI assistant powered by Claude Code that lives in Slack. It reads my emails, manages my reminders, runs scheduled briefings, and automates browser tasks. Here's how it works."
+description: "I built Autumn, a personal AI assistant that lives in Slack and runs on Claude Code. Here's how a Go bot, a CLAUDE.md playbook, and cron jobs make it work."
+keywords:
+  - "personal AI assistant in Slack"
+  - "Claude Code personal assistant"
+  - "CLAUDE.md playbook"
+  - "build AI assistant with Claude Code"
+  - "Claude Code Slack bot"
+  - "AI assistant cron jobs"
+  - "Playwright MCP browser automation"
+  - "Go Slack bot Claude Code"
+related:
+  - "my-new-ai-first-development-workflow-github-issues"
+  - "i-built-a-tradier-cli-because-ai-agents-deserve-better-tools"
+  - "i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one"
 og_image: "/images/autumn-ai-assistant.png"
 ---
 

--- a/content/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.html
+++ b/content/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.html
@@ -2,7 +2,20 @@
 title: "I Built a Tradier CLI Because AI Agents Deserve Better Tools"
 date: 2026-03-18T08:00:00-07:00
 draft: false
-description: "MCP servers flood your AI agent's context window with massive JSON payloads. A CLI gives it exactly what it needs. Here's why I built a full Tradier brokerage CLI in Go — and why CLIs are the better interface for AI-powered trading workflows."
+description: "I built a full Tradier brokerage CLI in Go so AI agents like Claude Code can trade without flooding the context window. Here is why CLIs beat MCP servers."
+keywords:
+  - "Tradier CLI"
+  - "CLI vs MCP server for AI agents"
+  - "AI agent trading tools"
+  - "Claude Code brokerage automation"
+  - "Tradier API command line"
+  - "options trading CLI"
+  - "CLI for AI agents"
+  - "AI options trading workflow"
+related:
+  - "why-i-built-a-cli-for-massive-financial-data"
+  - "full-circle-back-to-the-terminal"
+  - "the-stock-market-is-a-drunken-idiot-you-should-profit-from-it"
 og_image: "/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png"
 ---
 

--- a/content/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.html
+++ b/content/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.html
@@ -2,7 +2,20 @@
 title: "I Vibe Coded a Screenshot Tool Because Claude Code Needed One"
 date: 2026-02-24T12:00:00-07:00
 draft: false
-description: "I've been living in the terminal with Claude Code, Neovim, and tmux. But sharing screenshots with an AI that lives in a terminal session? That was broken. So I vibe coded a macOS screenshot tool that uploads to S3 and gives me a direct URL. Problem solved."
+description: "Sharing screenshots with Claude Code over SSH was broken, so I vibe coded a macOS menu bar app that uploads to S3 and drops a direct image URL on my clipboard."
+keywords:
+  - "share screenshots with Claude Code"
+  - "macOS screenshot to S3 tool"
+  - "Claude Code terminal SSH workflow"
+  - "vibe coding a macOS app"
+  - "screenshot direct image URL clipboard"
+  - "Swift menu bar screenshot tool"
+  - "AWS S3 pre-signed URL screenshot"
+  - "open source screenshot tool for AI"
+related:
+  - "full-circle-back-to-the-terminal"
+  - "i-built-a-tradier-cli-because-ai-agents-deserve-better-tools"
+  - "my-new-ai-first-development-workflow-github-issues"
 og_image: "/images/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.png"
 ---
 

--- a/content/blog/introducing-spice-edit.html
+++ b/content/blog/introducing-spice-edit.html
@@ -2,7 +2,20 @@
 title: "Introducing SpiceEdit: The Mouse-First Terminal Editor for the AI Era"
 date: 2026-04-30T12:00:00-07:00
 draft: false
-description: "I went full circle back to the terminal, but Vim never quite fit. So I vibe coded SpiceEdit — a mouse-first terminal code editor for engineers who live in tmux and SSH, without a four-thousand-line vimrc. One Go binary. MIT licensed. Free forever."
+description: "I vibe coded SpiceEdit, a mouse-first terminal code editor for AI-era devs who live in tmux and SSH. One Go binary, no vimrc, MIT licensed, free forever."
+keywords:
+  - "mouse-first terminal code editor"
+  - "terminal code editor for AI workflow"
+  - "Vim alternative terminal editor"
+  - "Go terminal editor single binary"
+  - "SpiceEdit editor"
+  - "best terminal editor for tmux and SSH"
+  - "easy terminal editor instead of Neovim"
+  - "OSC 52 SSH clipboard editor"
+related:
+  - "full-circle-back-to-the-terminal"
+  - "i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one"
+  - "i-built-a-tradier-cli-because-ai-agents-deserve-better-tools"
 og_image: "/images/blog/introducing-spice-edit.png"
 ---
 

--- a/content/blog/just-do-stuff.html
+++ b/content/blog/just-do-stuff.html
@@ -2,7 +2,20 @@
 title: "Just Do Stuff"
 date: 2026-02-03T12:00:00-07:00
 draft: false
-description: "The most underrated career strategy isn't optimizing for ROI — it's just doing stuff. Putting things into the world consistently, without overthinking the return, has generated hundreds of thousands of dollars in opportunities over 20 years."
+description: "For 20 years I've \"just done stuff\" — publishing without calculating ROI. That handful of posts quietly generated hundreds of thousands of dollars."
+keywords:
+  - "just do stuff career strategy"
+  - "you can just do things"
+  - "how blogging leads to business opportunities"
+  - "publishing your work increases your luck"
+  - "building in public for developers"
+  - "why blog with low traffic"
+  - "creating luck surface area"
+  - "consistency over optimization"
+related:
+  - "hello-world-my-new-blog-hugo-tailwind-css-and-more"
+  - "the-ai-side-hustle-revolution-turning-niche-ideas-into-income"
+  - "you-dont-lack-time-you-lack-a-system"
 og_image: "/images/blog/just-do-stuff.jpg"
 ---
 

--- a/content/blog/looking-for-a-new-cpa.html
+++ b/content/blog/looking-for-a-new-cpa.html
@@ -2,7 +2,20 @@
 title: "I'm Looking for a New CPA"
 date: 2026-04-20T08:00:00-07:00
 draft: false
-description: "For 15 years I had a CPA I trusted. She worked from home, we did almost everything by email, and tax season felt manageable. Since she retired I've been trying to find that same relationship — digital-first, responsive, and organized — and I haven't. Here's what I'm looking for."
+description: "For 15 years I had a digital-first CPA I trusted. Since she retired I can't find a responsive, organized replacement. Here's exactly what I'm looking for."
+keywords:
+  - "looking for a new CPA"
+  - "digital-first CPA"
+  - "CPA who works by email"
+  - "finding a responsive CPA"
+  - "CPA for complex taxes"
+  - "asynchronous CPA communication"
+  - "CPA in the age of AI"
+  - "remote CPA for tax preparation"
+related:
+  - "am-over-vendors-that-are-not-transparent-in-pricing"
+  - "i-built-a-personal-ai-assistant-that-lives-in-slack"
+  - "why-100-customers-at-200-beats-1000-at-20"
 og_image: "/images/blog/looking-for-a-new-cpa.jpg"
 ---
 

--- a/content/blog/my-new-ai-first-development-workflow-github-issues.html
+++ b/content/blog/my-new-ai-first-development-workflow-github-issues.html
@@ -2,7 +2,20 @@
 title: "My New AI-First Development Workflow - Github Issues"
 date: 2025-12-29T10:00:00-07:00
 draft: false
-description: "How I transformed my development workflow by treating GitHub Issues as both my project management system and planning document, with Claude at the command line as my primary collaborator."
+description: "Here's how I rebuilt my dev workflow around GitHub Issues as planning docs and Claude at the command line to scope, build, and ship code with far less overhead."
+keywords:
+  - "AI-first development workflow with GitHub Issues"
+  - "GitHub Issues as planning documents"
+  - "Claude Code CLI development workflow"
+  - "using GitHub CLI with AI agents"
+  - "GitHub Issues vs Jira and Asana"
+  - "why I don't use MCP servers"
+  - "AI coding workflow for developers"
+  - "turn GitHub issues into pull requests with AI"
+related:
+  - "i-built-a-tradier-cli-because-ai-agents-deserve-better-tools"
+  - "i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one"
+  - "full-circle-back-to-the-terminal"
 og_image: "/images/github-issues.png"
 ---
 

--- a/content/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit.html
+++ b/content/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit.html
@@ -2,8 +2,20 @@
 title: "Nitpicking Code Quality: A Necessary Evil or a Harmful Habit?"
 date: 2023-03-22T13:18:58-07:00
 draft: false
-description: "While Frank and I would agree on almost every software development principle in a perfect world, for me, the perfect world comes at a cost that I don't believe is worth it for most
-projects."
+description: "I think nitpicking in code reviews kills developer motivation. Here's why blocking PRs over style issues costs small teams more than it ever saves."
+keywords:
+  - "nitpicking in code reviews"
+  - "code review nitpicks"
+  - "pull request nitpicking"
+  - "code quality vs developer motivation"
+  - "blocking PRs over style issues"
+  - "code review culture at small companies"
+  - "big tech vs startup engineering culture"
+  - "keeping developers in flow"
+related:
+  - "streamlining-code-reviews-maximize-efficiency-and-effectiveness"
+  - "spicers-rules-on-how-and-when-to-test-your-code"
+  - "prioritizing-tdd-friendly-languages-and-frameworks"
 og_image: "/images/computer-code.jpg"
 ---
 

--- a/content/blog/prioritizing-tdd-friendly-languages-and-frameworks.html
+++ b/content/blog/prioritizing-tdd-friendly-languages-and-frameworks.html
@@ -2,7 +2,20 @@
 title: "Prioritizing TDD Friendly Languages and Frameworks"
 date: 2023-03-18T20:18:58-07:00
 draft: false
-description: ""
+description: "I pick TDD friendly languages and frameworks like Go and PHP over hard-to-test options like Node.js, and here's why testing should speed you up, not slow you down."
+keywords:
+  - "TDD friendly languages and frameworks"
+  - "best languages for test-driven development"
+  - "is Go good for TDD"
+  - "why Node.js is hard to test"
+  - "choosing a language for unit testing"
+  - "PHP unit testing vs JavaScript"
+  - "test-driven development language choice"
+  - "easiest languages to write unit tests"
+related:
+  - "spicers-rules-on-how-and-when-to-test-your-code"
+  - "nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit"
+  - "full-circle-back-to-the-terminal"
 og_image: "/images/computer-code.jpg"
 ---
 
@@ -16,8 +29,8 @@ og_image: "/images/computer-code.jpg"
   more enjoyable and not be an extra burden. They should be tools that help developers work faster, rather than additional tasks.
 </p>
 
-<blockquote className="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
-  <p className="mb-2">"Said a different way, unit tests when written to speed up my development process are amazing, but they are super annoying when written as a chore."</p>
+<blockquote class="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
+  <p class="mb-2">"Said a different way, unit tests when written to speed up my development process are amazing, but they are super annoying when written as a chore."</p>
 </blockquote>
 
 <p>

--- a/content/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity.html
+++ b/content/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity.html
@@ -2,7 +2,20 @@
 title: "Reimagining Real Estate: A Call for Excellence Over Exclusivity"
 date: 2024-03-26T12:18:58-07:00
 draft: false
-description: "Exploring the need for excellence over barriers in real estate, advocating for innovation and fairness in the industry."
+description: "After 50+ real estate deals, I argue the NAR commission settlement should push the industry to compete on excellence, not moats like MLS control."
+keywords:
+  - "NAR commission settlement"
+  - "National Association of Realtors lawsuit"
+  - "real estate agent commissions explained"
+  - "buying a home without a realtor"
+  - "real estate industry reform"
+  - "MLS access restrictions"
+  - "are realtor commissions worth it"
+  - "real estate moat"
+related:
+  - "am-over-vendors-that-are-not-transparent-in-pricing"
+  - "how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too"
+  - "delighting-customers-with-airbnb"
 og_image: "/images/moat.jpeg"
 ---
 

--- a/content/blog/remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses.html
+++ b/content/blog/remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses.html
@@ -2,7 +2,20 @@
 title: "Remodeling My Home Proved One Thing: We Need Robots to Build Houses"
 date: 2025-12-02T10:00:00-08:00
 draft: false
-description: "How a 2,000-square-foot remodel showed me just how broken, wasteful, and middleman-heavy the construction industry has become—and why I’m rooting for robots to take over."
+description: "I got $300K+ bids to remodel my home, then did it myself as GC for under $100K. Here's where construction money really goes, and why I want robots building houses."
+keywords:
+  - "cost of home remodel vs general contractor bids"
+  - "why are remodel bids so expensive"
+  - "acting as your own general contractor"
+  - "design build firm cost vs DIY GC"
+  - "where does construction money go middlemen"
+  - "robots building houses construction automation"
+  - "2000 square foot remodel cost"
+  - "residential construction industry waste"
+related:
+  - "am-over-vendors-that-are-not-transparent-in-pricing"
+  - "how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too"
+  - "reimagining-real-estate-a-call-for-excellence-over-exclusivity"
 og_image: "/images/robots-building-houses.jpg"
 ---
 

--- a/content/blog/spicers-rules-on-how-and-when-to-test-your-code.html
+++ b/content/blog/spicers-rules-on-how-and-when-to-test-your-code.html
@@ -2,8 +2,20 @@
 title: "Spicer's Rules on How and When To Test Your Code"
 date: 2019-09-15T12:18:58-07:00
 draft: false
-description: "Unit Testing is just one area where synchronization is important. Software development should proceed in conjunction with business objectives. Often, software developer ideologies and business goals run in conflict with each other, and
-I believe they should be in sync."
+description: "After 20 years writing code, here are my 8 practical rules for when and how to unit test, balancing TDD, coverage, and budget against real business goals."
+keywords:
+  - "when to write unit tests"
+  - "how and when to test your code"
+  - "balancing unit testing with business goals"
+  - "test-driven development pros and cons"
+  - "is 100% test coverage worth it"
+  - "unit testing vs integration testing"
+  - "pragmatic software testing strategy"
+  - "when to skip writing tests"
+related:
+  - "prioritizing-tdd-friendly-languages-and-frameworks"
+  - "nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit"
+  - "streamlining-code-reviews-maximize-efficiency-and-effectiveness"
 og_image: "/images/talk-code-to-me.png"
 ---
 
@@ -87,8 +99,8 @@ og_image: "/images/talk-code-to-me.png"
 
 
 
-<blockquote className="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
-	<p className="mb-2">"With test-driven development, a 3 step development processed could be reduced down to 2."</p>
+<blockquote class="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
+	<p class="mb-2">"With test-driven development, a 3 step development processed could be reduced down to 2."</p>
 </blockquote>
 
 
@@ -124,8 +136,8 @@ og_image: "/images/talk-code-to-me.png"
 	weeks or months later and need to make modifications to that original code. Maybe a bug popped up, or the feature needs to be tweaked. David suggests that every time you open a file you make it better. </p>
 
 
-<blockquote className="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
-	<p className="mb-2">"That every time you open a file you should make it better."</p>
+<blockquote class="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
+	<p class="mb-2">"That every time you open a file you should make it better."</p>
 </blockquote>
 
 
@@ -147,8 +159,8 @@ og_image: "/images/talk-code-to-me.png"
 	into account. </p>
 
 
-<blockquote className="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
-	<p className="mb-2">"This incremental approach to increase test coverage at the end of the day might cost the same as doing it all at once but think about it in terms of cash flow."</p>
+<blockquote class="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
+	<p class="mb-2">"This incremental approach to increase test coverage at the end of the day might cost the same as doing it all at once but think about it in terms of cash flow."</p>
 </blockquote>
 
 

--- a/content/blog/streamlining-code-reviews-maximize-efficiency-and-effectiveness.html
+++ b/content/blog/streamlining-code-reviews-maximize-efficiency-and-effectiveness.html
@@ -2,7 +2,20 @@
 title: "Streamlining Code Reviews: Maximize Efficiency and Effectiveness"
 date: 2023-03-30T20:18:58-07:00
 draft: false
-description: "Rethinking code reviews: balance efficiency & impact, encourage developer discretion, prioritize robust QA workflow, and consider AI-driven solutions."
+description: "After years on different teams, here is my contrarian take on code reviews: make pull requests developer discretion, lean on QA, and let AI help."
+keywords:
+  - "streamlining code reviews"
+  - "code review best practices"
+  - "are pull requests worth it"
+  - "code review at developer discretion"
+  - "QA workflow vs code reviews"
+  - "AI code review"
+  - "reducing pull request overhead"
+  - "code review process for small teams"
+related:
+  - "nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit"
+  - "spicers-rules-on-how-and-when-to-test-your-code"
+  - "my-new-ai-first-development-workflow-github-issues"
 og_image: "/images/code-review.jpg"
 ---
 

--- a/content/blog/the-ai-side-hustle-revolution-turning-niche-ideas-into-income.html
+++ b/content/blog/the-ai-side-hustle-revolution-turning-niche-ideas-into-income.html
@@ -2,7 +2,20 @@
 title: "The AI Side Hustle Revolution: Turning Niche Ideas into Income"
 date: 2025-06-06T10:00:00-07:00
 draft: false
-description: "How AI tools like Claude and GitHub Copilot enabled me to build OregonPastDueRent.com in under 80 hours and $1000, proving that niche software ideas are now profitable side hustles for developers."
+description: "I built OregonPastDueRent.com in under 80 hours and $1000 using Claude and GitHub Copilot. Here's why AI makes niche software a real side hustle for developers."
+keywords:
+  - "AI side hustle for developers"
+  - "building niche software with AI"
+  - "vibe coding a product"
+  - "build a SaaS with Claude and GitHub Copilot"
+  - "niche micro-SaaS business ideas"
+  - "make money as a software developer with AI"
+  - "launch a side project in 80 hours"
+  - "AI coding tools to build a startup"
+related:
+  - "just-do-stuff"
+  - "i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one"
+  - "why-100-customers-at-200-beats-1000-at-20"
 og_image: "/images/ai-side-hustle-coding.jpg"
 ---
 

--- a/content/blog/the-stock-market-is-a-drunken-idiot-you-should-profit-from-it.html
+++ b/content/blog/the-stock-market-is-a-drunken-idiot-you-should-profit-from-it.html
@@ -2,7 +2,20 @@
 title: "The Stock Market Is a Drunken Idiot -- You Should Profit From It"
 date: 2023-02-24T20:18:58-07:00
 draft: false
-description: ""
+description: "I treat erratic stocks like drunk people: loud, volatile, and surprisingly predictable. Here's how I spot volatile stocks and swing trade the chaos for profit."
+keywords:
+  - "how to spot volatile stocks for swing trading"
+  - "identify volatile stocks to trade"
+  - "trading high volatility meme stocks"
+  - "swing trading volatile stocks strategy"
+  - "using volume to find volatile stocks"
+  - "how to profit from stock market volatility"
+  - "GameStop AMC meme stock volatility"
+  - "signs a stock is about to make a big move"
+related:
+  - "how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too"
+  - "i-built-a-tradier-cli-because-ai-agents-deserve-better-tools"
+  - "why-i-built-a-cli-for-massive-financial-data"
 og_image: "/images/drunk-people-dancing.jpg"
 ---
 
@@ -55,8 +68,8 @@ og_image: "/images/drunk-people-dancing.jpg"
   before they crash, recover from a hangover, and get back to normal. These are trading opportunities.
 </p>
 
-<blockquote className="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
-  <p className="mb-2">
+<blockquote class="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
+  <p class="mb-2">
     I should note that day traders can also make the same comparison, but I'm talking more about swing trading. You might profit over the course of a few days, weeks, or months by
     identifying a drunken stock. These stocks are very predictable, just like a drunken person.
   </p>

--- a/content/blog/using-hugo-with-google-docs.html
+++ b/content/blog/using-hugo-with-google-docs.html
@@ -2,8 +2,18 @@
 title: "Using Hugo with Google Docs"
 date: 2019-08-01T12:18:58-07:00
 draft: false
-description: "I am becoming a big fan of Hugo to build static sites like this one and this one. Since Hugo does not ship with any fancy GUI as other content management systems do -- typically you produce your content within your text editor such as
-Atom."
+description: "I'm a big fan of Hugo, but I prefer writing in Google Docs. Here's my quick workflow for importing Google Docs into Hugo as clean, tidy HTML."
+keywords:
+  - "using Hugo with Google Docs"
+  - "import Google Docs into Hugo"
+  - "write Hugo posts in Google Docs"
+  - "clean up Google Docs HTML export"
+  - "Hugo content workflow"
+  - "convert Google Docs to clean HTML"
+  - "Hugo static site blogging tips"
+related:
+  - "hello-world-my-new-blog-hugo-tailwind-css-and-more"
+  - "full-circle-back-to-the-terminal"
 og_image: "/images/editing-hugo-post-in-atom.png"
 ---
 

--- a/content/blog/why-100-customers-at-200-beats-1000-at-20.html
+++ b/content/blog/why-100-customers-at-200-beats-1000-at-20.html
@@ -2,7 +2,20 @@
 title: "Why 100 Customers at $200 Beats 1,000 at $20"
 date: 2026-01-19T10:00:00-07:00
 draft: false
-description: "Getting 1,000 customers is brutal. But 100 customers at $200/month? That's $240k/year—and easier than you think. Here's why fewer customers means more profit."
+description: "I've started multiple SaaS products, and getting 1,000 customers crushes most founders. Here's why 100 customers at $200/month is the smarter path to $100k profit."
+keywords:
+  - "100 customers at $200 a month SaaS"
+  - "premium pricing for solo SaaS founders"
+  - "how many customers do you need to make $100k"
+  - "indie SaaS pricing strategy"
+  - "small SaaS business model"
+  - "charge more fewer customers"
+  - "niche SaaS premium pricing"
+  - "work backwards from income goal business"
+related:
+  - "just-do-stuff"
+  - "you-dont-lack-time-you-lack-a-system"
+  - "am-over-vendors-that-are-not-transparent-in-pricing"
 og_image: "/images/200-month.jpg"
 ---
 

--- a/content/blog/why-i-built-a-cli-for-massive-financial-data.html
+++ b/content/blog/why-i-built-a-cli-for-massive-financial-data.html
@@ -2,7 +2,20 @@
 title: "Why I Built a CLI for Massive Financial Data"
 date: 2026-02-16T10:00:00-07:00
 draft: false
-description: "MCP servers flood your AI agent's context window. A CLI doesn't. I built Massive CLI — a command-line tool for the Massive financial data API — because a single binary that outputs clean tables or JSON is a better fit for both humans and AI agents."
+description: "MCP servers flood your AI agent's context window. So I built Massive CLI, a command-line tool for the Massive financial data API that outputs clean tables or JSON."
+keywords:
+  - "CLI for financial market data"
+  - "Massive API CLI"
+  - "CLI vs MCP server for AI agents"
+  - "financial data CLI for Claude Code"
+  - "stock and options market data command line tool"
+  - "AI agent tools without context window bloat"
+  - "Go CLI for market data API"
+  - "real-time market data terminal tool"
+related:
+  - "i-built-a-tradier-cli-because-ai-agents-deserve-better-tools"
+  - "my-new-ai-first-development-workflow-github-issues"
+  - "i-built-a-personal-ai-assistant-that-lives-in-slack"
 og_image: "/images/blog/massive-cli.jpg"
 ---
 

--- a/content/blog/you-dont-lack-time-you-lack-a-system.html
+++ b/content/blog/you-dont-lack-time-you-lack-a-system.html
@@ -2,7 +2,20 @@
 title: "You Don't Lack Time. You Lack a System."
 date: 2026-01-13T10:00:00-07:00
 draft: false
-description: "Most of us don't need more hours in the day—we need systems that protect our attention and reduce friction. Here's how small changes compound into a life spent on what actually matters."
+description: "I don't need more hours in the day, and neither do you. Here's how I build systems that protect my attention, reduce friction, and compound into real time."
+keywords:
+  - "building systems to manage your time"
+  - "you don't lack time you lack a system"
+  - "systems to protect your attention"
+  - "automate outsource eliminate repetitive tasks"
+  - "deep work and reducing friction"
+  - "time management systems for entrepreneurs"
+  - "batching email and text messages"
+  - "compound effect of small time savings"
+related:
+  - "just-do-stuff"
+  - "i-built-a-personal-ai-assistant-that-lives-in-slack"
+  - "my-new-ai-first-development-workflow-github-issues"
 og_image: "/images/system.png"
 ---
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -3,28 +3,41 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>404 Page not found</title>
-  <meta name="description" content="" />
+
+  
+  <title>404 Page not found | Spicer Matthews</title>
+  <meta name="description" content="Spicer Matthews is a software developer, entrepreneur, and options trader in Newberg, Oregon — writing about AI-first development, building products, and options trading." />
+  <meta name="keywords" content="Spicer Matthews, software developer, options trading, entrepreneur, AI-first development, Claude Code, Hugo static site, Newberg Oregon" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="noindex, follow" />
+  <link rel="canonical" href="https://spicermatthews.com/404.html" />
+
   <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
 
   
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="404 Page not found" />
-  <meta property="og:description" content="" />
+  <meta property="og:title" content="404 Page not found | Spicer Matthews" />
+  <meta property="og:description" content="Spicer Matthews is a software developer, entrepreneur, and options trader in Newberg, Oregon — writing about AI-first development, building products, and options trading." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/404.html" />
-  <meta property="og:locale" content="en" />
-
-  
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:alt" content="404 Page not found" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-  
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="" />
+  <meta name="twitter:title" content="404 Page not found | Spicer Matthews" />
+  <meta name="twitter:description" content="Spicer Matthews is a software developer, entrepreneur, and options trader in Newberg, Oregon — writing about AI-first development, building products, and options trading." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","description":"Spicer Matthews is a software developer, entrepreneur, and options trader in Newberg, Oregon — writing about AI-first development, building products, and options trading.","inLanguage":"en-US","isPartOf":{"@id":"https://spicermatthews.com/#website"},"name":"404 Page not found","url":"https://spicermatthews.com/404.html"}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">

--- a/docs/blog/am-over-vendors-that-are-not-transparent-in-pricing/index.html
+++ b/docs/blog/am-over-vendors-that-are-not-transparent-in-pricing/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Am Over Vendors That Are Not Transparent in Pricing</title>
-  <meta name="description" content="The days of secret per customer pricing should be over. Vendors should be transparent with pricing and treat all customers the same." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Am Over Vendors That Are Not Transparent in Pricing" />
-  <meta property="og:description" content="The days of secret per customer pricing should be over. Vendors should be transparent with pricing and treat all customers the same." />
+  <title>I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing | Spicer Matthews</title>
+  <meta name="description" content="I&#39;m done with vendors that hide pricing and reward schmoozing over fairness. Here&#39;s why transparent pricing that treats every customer the same wins my business." />
+  <meta name="keywords" content="transparent pricing for vendors, secret per-customer pricing, construction supplier pricing, why suppliers charge different prices, Home Depot vs local supplier pricing, fair pricing for all customers, relationship-based pricing in construction, building material pricing transparency" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing | Spicer Matthews" />
+  <meta property="og:description" content="I&#39;m done with vendors that hide pricing and reward schmoozing over fairness. Here&#39;s why transparent pricing that treats every customer the same wins my business." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/vendor-sales-person.png" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/vendor-sales-person.png" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/vendor-sales-person.png" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/vendor-sales-person.png" />
+  <meta property="og:image:alt" content="I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing" />
+  <meta property="article:published_time" content="2020-04-21T20:18:58-07:00" />
+  <meta property="article:modified_time" content="2020-04-21T20:18:58-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="transparent pricing for vendors" />
+  <meta property="article:tag" content="secret per-customer pricing" />
+  <meta property="article:tag" content="construction supplier pricing" />
+  <meta property="article:tag" content="why suppliers charge different prices" />
+  <meta property="article:tag" content="Home Depot vs local supplier pricing" />
+  <meta property="article:tag" content="fair pricing for all customers" />
+  <meta property="article:tag" content="relationship-based pricing in construction" />
+  <meta property="article:tag" content="building material pricing transparency" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/vendor-sales-person.png" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="The days of secret per customer pricing should be over. Vendors should be transparent with pricing and treat all customers the same." />
+  <meta name="twitter:title" content="I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing | Spicer Matthews" />
+  <meta name="twitter:description" content="I&#39;m done with vendors that hide pricing and reward schmoozing over fairness. Here&#39;s why transparent pricing that treats every customer the same wins my business." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/vendor-sales-person.png" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2020-04-21T20:18:58-07:00","datePublished":"2020-04-21T20:18:58-07:00","description":"I'm done with vendors that hide pricing and reward schmoozing over fairness. Here's why transparent pricing that treats every customer the same wins my business.","headline":"I'm Over Vendors That Aren't Transparent About Pricing","image":["https://spicermatthews.com/images/vendor-sales-person.png"],"inLanguage":"en-US","keywords":"transparent pricing for vendors, secret per-customer pricing, construction supplier pricing, why suppliers charge different prices, Home Depot vs local supplier pricing, fair pricing for all customers, relationship-based pricing in construction, building material pricing transparency","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/","@type":"WebPage"},"name":"I'm Over Vendors That Aren't Transparent About Pricing","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/","wordCount":757}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/","name":"I'm Over Vendors That Aren't Transparent About Pricing","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -93,7 +118,7 @@
         </svg>
         Back to Blog
       </a>
-      <h1 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Am Over Vendors That Are Not Transparent in Pricing</h1>
+      <h1 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing</h1>
       <div class="flex items-center text-gray-600">
         <time>April 21, 2020</time>
         
@@ -107,7 +132,7 @@
   
   
   <div class="max-w-4xl mx-auto">
-    <img src="/images/vendor-sales-person.png" alt="Am Over Vendors That Are Not Transparent in Pricing" class="w-full h-64 md:h-96 object-cover" />
+    <img src="/images/vendor-sales-person.png" alt="I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing" class="w-full h-64 md:h-96 object-cover" />
   </div>
   
 
@@ -194,11 +219,33 @@
     <div class="mt-8 pt-8 border-t">
       <h3 class="font-semibold text-gray-900 mb-4">Share this post</h3>
       <div class="flex space-x-4">
-        <a href="https://twitter.com/intent/tweet?text=Am&#43;Over&#43;Vendors&#43;That&#43;Are&#43;Not&#43;Transparent&#43;in&#43;Pricing&url=https%3A%2F%2Fspicermatthews.com%2Fblog%2Fam-over-vendors-that-are-not-transparent-in-pricing%2F&via=spicermatthews" target="_blank" class="inline-flex items-center px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 no-underline">
+        <a href="https://twitter.com/intent/tweet?text=I%27m&#43;Over&#43;Vendors&#43;That&#43;Aren%27t&#43;Transparent&#43;About&#43;Pricing&url=https%3A%2F%2Fspicermatthews.com%2Fblog%2Fam-over-vendors-that-are-not-transparent-in-pricing%2F&via=spicermatthews" target="_blank" class="inline-flex items-center px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 no-underline">
           <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too/" class="block no-underline group">
+          <img src="/images/construction-home-project.png" alt="How I Learned to Spot Inflated Bids (and What You Can Do Too)" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">How I Learned to Spot Inflated Bids (and What You Can Do Too)</span>
+          <time class="block text-sm text-gray-500 mt-1">October 15, 2025</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/why-100-customers-at-200-beats-1000-at-20/" class="block no-underline group">
+          <img src="/images/200-month.jpg" alt="Why 100 Customers at $200 Beats 1,000 at $20" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Why 100 Customers at $200 Beats 1,000 at $20</span>
+          <time class="block text-sm text-gray-500 mt-1">January 19, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses/" class="block no-underline group">
+          <img src="/images/robots-building-houses.jpg" alt="Remodeling My Home Proved One Thing: We Need Robots to Build Houses" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Remodeling My Home Proved One Thing: We Need Robots to Build Houses</span>
+          <time class="block text-sm text-gray-500 mt-1">December 2, 2025</time>
         </a>
       </div>
     </div>

--- a/docs/blog/delighting-customers-with-airbnb/index.html
+++ b/docs/blog/delighting-customers-with-airbnb/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Delighting Customers With Airbnb</title>
-  <meta name="description" content="This week, we launched bendmountbachelorvillage.com for really no good reason. For years now, we have been using Airbnb to rent out our vacation rental in Bend, OR." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Delighting Customers With Airbnb" />
-  <meta property="og:description" content="This week, we launched bendmountbachelorvillage.com for really no good reason. For years now, we have been using Airbnb to rent out our vacation rental in Bend, OR." />
+  <title>Delighting Customers With Airbnb | Spicer Matthews</title>
+  <meta name="description" content="Why my wife and I obsess over delighting customers, from our grandfather&#39;s NAPA store to our software businesses and Airbnb guests in Bend, Oregon." />
+  <meta name="keywords" content="delighting customers, how to delight customers, delighting Airbnb guests, customer experience as a business strategy, Airbnb host tips for guests, customer retention through delight, Bend Oregon vacation rental, building customer relationships" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/delighting-customers-with-airbnb/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Delighting Customers With Airbnb | Spicer Matthews" />
+  <meta property="og:description" content="Why my wife and I obsess over delighting customers, from our grandfather&#39;s NAPA store to our software businesses and Airbnb guests in Bend, Oregon." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/delighting-customers-with-airbnb/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/condo-rental-in-bend-oregon.png" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/condo-rental-in-bend-oregon.png" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/condo-rental-in-bend-oregon.png" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/condo-rental-in-bend-oregon.png" />
+  <meta property="og:image:alt" content="Delighting Customers With Airbnb" />
+  <meta property="article:published_time" content="2019-07-30T12:18:58-07:00" />
+  <meta property="article:modified_time" content="2019-07-30T12:18:58-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="delighting customers" />
+  <meta property="article:tag" content="how to delight customers" />
+  <meta property="article:tag" content="delighting Airbnb guests" />
+  <meta property="article:tag" content="customer experience as a business strategy" />
+  <meta property="article:tag" content="Airbnb host tips for guests" />
+  <meta property="article:tag" content="customer retention through delight" />
+  <meta property="article:tag" content="Bend Oregon vacation rental" />
+  <meta property="article:tag" content="building customer relationships" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/condo-rental-in-bend-oregon.png" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="This week, we launched bendmountbachelorvillage.com for really no good reason. For years now, we have been using Airbnb to rent out our vacation rental in Bend, OR." />
+  <meta name="twitter:title" content="Delighting Customers With Airbnb | Spicer Matthews" />
+  <meta name="twitter:description" content="Why my wife and I obsess over delighting customers, from our grandfather&#39;s NAPA store to our software businesses and Airbnb guests in Bend, Oregon." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/condo-rental-in-bend-oregon.png" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2019-07-30T12:18:58-07:00","datePublished":"2019-07-30T12:18:58-07:00","description":"Why my wife and I obsess over delighting customers, from our grandfather's NAPA store to our software businesses and Airbnb guests in Bend, Oregon.","headline":"Delighting Customers With Airbnb","image":["https://spicermatthews.com/images/condo-rental-in-bend-oregon.png"],"inLanguage":"en-US","keywords":"delighting customers, how to delight customers, delighting Airbnb guests, customer experience as a business strategy, Airbnb host tips for guests, customer retention through delight, Bend Oregon vacation rental, building customer relationships","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/delighting-customers-with-airbnb/","@type":"WebPage"},"name":"Delighting Customers With Airbnb","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/delighting-customers-with-airbnb/","wordCount":650}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/delighting-customers-with-airbnb/","name":"Delighting Customers With Airbnb","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -243,6 +268,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/why-100-customers-at-200-beats-1000-at-20/" class="block no-underline group">
+          <img src="/images/200-month.jpg" alt="Why 100 Customers at $200 Beats 1,000 at $20" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Why 100 Customers at $200 Beats 1,000 at $20</span>
+          <time class="block text-sm text-gray-500 mt-1">January 19, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more/" class="block no-underline group">
+          <img src="/images/spicer-matthews-wine-drinking.jpg" alt="Hello World: My New Blog, Hugo, Tailwind CSS, and More" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Hello World: My New Blog, Hugo, Tailwind CSS, and More</span>
+          <time class="block text-sm text-gray-500 mt-1">July 17, 2019</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity/" class="block no-underline group">
+          <img src="/images/moat.jpeg" alt="Reimagining Real Estate: A Call for Excellence Over Exclusivity" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Reimagining Real Estate: A Call for Excellence Over Exclusivity</span>
+          <time class="block text-sm text-gray-500 mt-1">March 26, 2024</time>
         </a>
       </div>
     </div>

--- a/docs/blog/full-circle-back-to-the-terminal/index.html
+++ b/docs/blog/full-circle-back-to-the-terminal/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Full Circle: Back to the Terminal</title>
-  <meta name="description" content="I started my career in the late 90s doing everything in the terminal. Over 30 years I migrated to GUIs, web apps, and desktop tools. Now, thanks to Claude Code, Neovim, and tmux, I&#39;m back where I started — and it&#39;s never felt better." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Full Circle: Back to the Terminal" />
-  <meta property="og:description" content="I started my career in the late 90s doing everything in the terminal. Over 30 years I migrated to GUIs, web apps, and desktop tools. Now, thanks to Claude Code, Neovim, and tmux, I&#39;m back where I started — and it&#39;s never felt better." />
+  <title>Full Circle: Back to the Terminal | Spicer Matthews</title>
+  <meta name="description" content="After 30 years in GUIs, I&#39;m back in the terminal full-time with Claude Code, Neovim, and tmux. Here&#39;s my development workflow and why it feels like home." />
+  <meta name="keywords" content="terminal development workflow, Claude Code tmux Neovim, Neovim vs VS Code, tmux workflow for developers, managing dotfiles with GNU Stow, LazyVim terminal IDE, developer terminal setup 2026, living in the terminal" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/full-circle-back-to-the-terminal/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Full Circle: Back to the Terminal | Spicer Matthews" />
+  <meta property="og:description" content="After 30 years in GUIs, I&#39;m back in the terminal full-time with Claude Code, Neovim, and tmux. Here&#39;s my development workflow and why it feels like home." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/full-circle-back-to-the-terminal/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/blog/full-circle-back-to-the-terminal.jpg" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/full-circle-back-to-the-terminal.jpg" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/blog/full-circle-back-to-the-terminal.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/full-circle-back-to-the-terminal.jpg" />
+  <meta property="og:image:alt" content="Full Circle: Back to the Terminal" />
+  <meta property="article:published_time" content="2026-02-19T12:00:00-07:00" />
+  <meta property="article:modified_time" content="2026-02-19T12:00:00-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="terminal development workflow" />
+  <meta property="article:tag" content="Claude Code tmux Neovim" />
+  <meta property="article:tag" content="Neovim vs VS Code" />
+  <meta property="article:tag" content="tmux workflow for developers" />
+  <meta property="article:tag" content="managing dotfiles with GNU Stow" />
+  <meta property="article:tag" content="LazyVim terminal IDE" />
+  <meta property="article:tag" content="developer terminal setup 2026" />
+  <meta property="article:tag" content="living in the terminal" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/blog/full-circle-back-to-the-terminal.jpg" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="I started my career in the late 90s doing everything in the terminal. Over 30 years I migrated to GUIs, web apps, and desktop tools. Now, thanks to Claude Code, Neovim, and tmux, I&#39;m back where I started — and it&#39;s never felt better." />
+  <meta name="twitter:title" content="Full Circle: Back to the Terminal | Spicer Matthews" />
+  <meta name="twitter:description" content="After 30 years in GUIs, I&#39;m back in the terminal full-time with Claude Code, Neovim, and tmux. Here&#39;s my development workflow and why it feels like home." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/blog/full-circle-back-to-the-terminal.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2026-02-19T12:00:00-07:00","datePublished":"2026-02-19T12:00:00-07:00","description":"After 30 years in GUIs, I'm back in the terminal full-time with Claude Code, Neovim, and tmux. Here's my development workflow and why it feels like home.","headline":"Full Circle: Back to the Terminal","image":["https://spicermatthews.com/images/blog/full-circle-back-to-the-terminal.jpg"],"inLanguage":"en-US","keywords":"terminal development workflow, Claude Code tmux Neovim, Neovim vs VS Code, tmux workflow for developers, managing dotfiles with GNU Stow, LazyVim terminal IDE, developer terminal setup 2026, living in the terminal","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/full-circle-back-to-the-terminal/","@type":"WebPage"},"name":"Full Circle: Back to the Terminal","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/full-circle-back-to-the-terminal/","wordCount":2008}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/full-circle-back-to-the-terminal/","name":"Full Circle: Back to the Terminal","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -509,6 +534,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/my-new-ai-first-development-workflow-github-issues/" class="block no-underline group">
+          <img src="/images/github-issues.png" alt="My New AI-First Development Workflow - Github Issues" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">My New AI-First Development Workflow - Github Issues</span>
+          <time class="block text-sm text-gray-500 mt-1">December 29, 2025</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/" class="block no-underline group">
+          <img src="/images/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.png" alt="I Vibe Coded a Screenshot Tool Because Claude Code Needed One" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Vibe Coded a Screenshot Tool Because Claude Code Needed One</span>
+          <time class="block text-sm text-gray-500 mt-1">February 24, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/" class="block no-underline group">
+          <img src="/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png" alt="I Built a Tradier CLI Because AI Agents Deserve Better Tools" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Built a Tradier CLI Because AI Agents Deserve Better Tools</span>
+          <time class="block text-sm text-gray-500 mt-1">March 18, 2026</time>
         </a>
       </div>
     </div>

--- a/docs/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more/index.html
+++ b/docs/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Hello World: My New Blog, Hugo, Tailwind CSS, and More</title>
-  <meta name="description" content="Today, I am launching, once again, my personal blog. Starting over. Welcome to the new spicermatthews.com" />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Hello World: My New Blog, Hugo, Tailwind CSS, and More" />
-  <meta property="og:description" content="Today, I am launching, once again, my personal blog. Starting over. Welcome to the new spicermatthews.com" />
+  <title>Hello World: My New Blog, Hugo, Tailwind CSS, and More | Spicer Matthews</title>
+  <meta name="description" content="I relaunched my personal blog as a static Hugo site styled with Tailwind CSS and hosted on GitHub Pages. Here&#39;s why I ditched the CMS headaches for good." />
+  <meta name="keywords" content="building a personal blog with Hugo and Tailwind CSS, Hugo static site on GitHub Pages, why I switched from a CMS to a static site, Tailwind CSS vs Bootstrap, Hugo static site generator for developers, low-maintenance personal blog, design your own site without a designer, Craft CMS alternative for personal blogs" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Hello World: My New Blog, Hugo, Tailwind CSS, and More | Spicer Matthews" />
+  <meta property="og:description" content="I relaunched my personal blog as a static Hugo site styled with Tailwind CSS and hosted on GitHub Pages. Here&#39;s why I ditched the CMS headaches for good." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:alt" content="Hello World: My New Blog, Hugo, Tailwind CSS, and More" />
+  <meta property="article:published_time" content="2019-07-17T19:02:38-07:00" />
+  <meta property="article:modified_time" content="2019-07-17T19:02:38-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="building a personal blog with Hugo and Tailwind CSS" />
+  <meta property="article:tag" content="Hugo static site on GitHub Pages" />
+  <meta property="article:tag" content="why I switched from a CMS to a static site" />
+  <meta property="article:tag" content="Tailwind CSS vs Bootstrap" />
+  <meta property="article:tag" content="Hugo static site generator for developers" />
+  <meta property="article:tag" content="low-maintenance personal blog" />
+  <meta property="article:tag" content="design your own site without a designer" />
+  <meta property="article:tag" content="Craft CMS alternative for personal blogs" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="Today, I am launching, once again, my personal blog. Starting over. Welcome to the new spicermatthews.com" />
+  <meta name="twitter:title" content="Hello World: My New Blog, Hugo, Tailwind CSS, and More | Spicer Matthews" />
+  <meta name="twitter:description" content="I relaunched my personal blog as a static Hugo site styled with Tailwind CSS and hosted on GitHub Pages. Here&#39;s why I ditched the CMS headaches for good." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2019-07-17T19:02:38-07:00","datePublished":"2019-07-17T19:02:38-07:00","description":"I relaunched my personal blog as a static Hugo site styled with Tailwind CSS and hosted on GitHub Pages. Here's why I ditched the CMS headaches for good.","headline":"Hello World: My New Blog, Hugo, Tailwind CSS, and More","image":["https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg"],"inLanguage":"en-US","keywords":"building a personal blog with Hugo and Tailwind CSS, Hugo static site on GitHub Pages, why I switched from a CMS to a static site, Tailwind CSS vs Bootstrap, Hugo static site generator for developers, low-maintenance personal blog, design your own site without a designer, Craft CMS alternative for personal blogs","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more/","@type":"WebPage"},"name":"Hello World: My New Blog, Hugo, Tailwind CSS, and More","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more/","wordCount":1102}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more/","name":"Hello World: My New Blog, Hugo, Tailwind CSS, and More","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -232,6 +257,23 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/using-hugo-with-google-docs/" class="block no-underline group">
+          <img src="/images/editing-hugo-post-in-atom.png" alt="Using Hugo with Google Docs" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Using Hugo with Google Docs</span>
+          <time class="block text-sm text-gray-500 mt-1">August 1, 2019</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/full-circle-back-to-the-terminal/" class="block no-underline group">
+          <img src="/images/blog/full-circle-back-to-the-terminal.jpg" alt="Full Circle: Back to the Terminal" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Full Circle: Back to the Terminal</span>
+          <time class="block text-sm text-gray-500 mt-1">February 19, 2026</time>
         </a>
       </div>
     </div>

--- a/docs/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too/index.html
+++ b/docs/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>How I Learned to Spot Inflated Bids (and What You Can Do Too)</title>
-  <meta name="description" content="After two decades as a hobbyist builder, I&#39;ve learned to spot when contractors are pricing the job—or pricing the lifestyle. Here&#39;s how to protect your budget and get fair quotes." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="How I Learned to Spot Inflated Bids (and What You Can Do Too)" />
-  <meta property="og:description" content="After two decades as a hobbyist builder, I&#39;ve learned to spot when contractors are pricing the job—or pricing the lifestyle. Here&#39;s how to protect your budget and get fair quotes." />
+  <title>How I Learned to Spot Inflated Bids (and What You Can Do Too) | Spicer Matthews</title>
+  <meta name="description" content="After two decades of building, I learned to spot inflated contractor bids and price-gouging. Here&#39;s how I get fair quotes and protect my renovation budget." />
+  <meta name="keywords" content="how to spot inflated contractor bids, contractor overcharging based on home value, how to get fair contractor quotes, why are my contractor quotes so high, negotiating contractor bids on a renovation, contractor sizing up customers, getting multiple bids for home projects, red flags when hiring a contractor" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="How I Learned to Spot Inflated Bids (and What You Can Do Too) | Spicer Matthews" />
+  <meta property="og:description" content="After two decades of building, I learned to spot inflated contractor bids and price-gouging. Here&#39;s how I get fair quotes and protect my renovation budget." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/construction-home-project.png" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/construction-home-project.png" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/construction-home-project.png" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/construction-home-project.png" />
+  <meta property="og:image:alt" content="How I Learned to Spot Inflated Bids (and What You Can Do Too)" />
+  <meta property="article:published_time" content="2025-10-15T10:00:00-07:00" />
+  <meta property="article:modified_time" content="2025-10-15T10:00:00-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="how to spot inflated contractor bids" />
+  <meta property="article:tag" content="contractor overcharging based on home value" />
+  <meta property="article:tag" content="how to get fair contractor quotes" />
+  <meta property="article:tag" content="why are my contractor quotes so high" />
+  <meta property="article:tag" content="negotiating contractor bids on a renovation" />
+  <meta property="article:tag" content="contractor sizing up customers" />
+  <meta property="article:tag" content="getting multiple bids for home projects" />
+  <meta property="article:tag" content="red flags when hiring a contractor" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/construction-home-project.png" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="After two decades as a hobbyist builder, I&#39;ve learned to spot when contractors are pricing the job—or pricing the lifestyle. Here&#39;s how to protect your budget and get fair quotes." />
+  <meta name="twitter:title" content="How I Learned to Spot Inflated Bids (and What You Can Do Too) | Spicer Matthews" />
+  <meta name="twitter:description" content="After two decades of building, I learned to spot inflated contractor bids and price-gouging. Here&#39;s how I get fair quotes and protect my renovation budget." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/construction-home-project.png" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2025-10-15T10:00:00-07:00","datePublished":"2025-10-15T10:00:00-07:00","description":"After two decades of building, I learned to spot inflated contractor bids and price-gouging. Here's how I get fair quotes and protect my renovation budget.","headline":"How I Learned to Spot Inflated Bids (and What You Can Do Too)","image":["https://spicermatthews.com/images/construction-home-project.png"],"inLanguage":"en-US","keywords":"how to spot inflated contractor bids, contractor overcharging based on home value, how to get fair contractor quotes, why are my contractor quotes so high, negotiating contractor bids on a renovation, contractor sizing up customers, getting multiple bids for home projects, red flags when hiring a contractor","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too/","@type":"WebPage"},"name":"How I Learned to Spot Inflated Bids (and What You Can Do Too)","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too/","wordCount":490}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too/","name":"How I Learned to Spot Inflated Bids (and What You Can Do Too)","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -221,6 +246,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses/" class="block no-underline group">
+          <img src="/images/robots-building-houses.jpg" alt="Remodeling My Home Proved One Thing: We Need Robots to Build Houses" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Remodeling My Home Proved One Thing: We Need Robots to Build Houses</span>
+          <time class="block text-sm text-gray-500 mt-1">December 2, 2025</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/" class="block no-underline group">
+          <img src="/images/vendor-sales-person.png" alt="I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing</span>
+          <time class="block text-sm text-gray-500 mt-1">April 21, 2020</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity/" class="block no-underline group">
+          <img src="/images/moat.jpeg" alt="Reimagining Real Estate: A Call for Excellence Over Exclusivity" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Reimagining Real Estate: A Call for Excellence Over Exclusivity</span>
+          <time class="block text-sm text-gray-500 mt-1">March 26, 2024</time>
         </a>
       </div>
     </div>

--- a/docs/blog/i-built-a-personal-ai-assistant-that-lives-in-slack/index.html
+++ b/docs/blog/i-built-a-personal-ai-assistant-that-lives-in-slack/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>I Built a Personal AI Assistant That Lives in Slack</title>
-  <meta name="description" content="Inspired by OpenClaw, I built Autumn — a personal AI assistant powered by Claude Code that lives in Slack. It reads my emails, manages my reminders, runs scheduled briefings, and automates browser tasks. Here&#39;s how it works." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="I Built a Personal AI Assistant That Lives in Slack" />
-  <meta property="og:description" content="Inspired by OpenClaw, I built Autumn — a personal AI assistant powered by Claude Code that lives in Slack. It reads my emails, manages my reminders, runs scheduled briefings, and automates browser tasks. Here&#39;s how it works." />
+  <title>I Built a Personal AI Assistant That Lives in Slack | Spicer Matthews</title>
+  <meta name="description" content="I built Autumn, a personal AI assistant that lives in Slack and runs on Claude Code. Here&#39;s how a Go bot, a CLAUDE.md playbook, and cron jobs make it work." />
+  <meta name="keywords" content="personal AI assistant in Slack, Claude Code personal assistant, CLAUDE.md playbook, build AI assistant with Claude Code, Claude Code Slack bot, AI assistant cron jobs, Playwright MCP browser automation, Go Slack bot Claude Code" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/i-built-a-personal-ai-assistant-that-lives-in-slack/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="I Built a Personal AI Assistant That Lives in Slack | Spicer Matthews" />
+  <meta property="og:description" content="I built Autumn, a personal AI assistant that lives in Slack and runs on Claude Code. Here&#39;s how a Go bot, a CLAUDE.md playbook, and cron jobs make it work." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/i-built-a-personal-ai-assistant-that-lives-in-slack/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/autumn-ai-assistant.png" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/autumn-ai-assistant.png" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/autumn-ai-assistant.png" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/autumn-ai-assistant.png" />
+  <meta property="og:image:alt" content="I Built a Personal AI Assistant That Lives in Slack" />
+  <meta property="article:published_time" content="2026-01-30T10:00:00-07:00" />
+  <meta property="article:modified_time" content="2026-01-30T10:00:00-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="personal AI assistant in Slack" />
+  <meta property="article:tag" content="Claude Code personal assistant" />
+  <meta property="article:tag" content="CLAUDE.md playbook" />
+  <meta property="article:tag" content="build AI assistant with Claude Code" />
+  <meta property="article:tag" content="Claude Code Slack bot" />
+  <meta property="article:tag" content="AI assistant cron jobs" />
+  <meta property="article:tag" content="Playwright MCP browser automation" />
+  <meta property="article:tag" content="Go Slack bot Claude Code" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/autumn-ai-assistant.png" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="Inspired by OpenClaw, I built Autumn — a personal AI assistant powered by Claude Code that lives in Slack. It reads my emails, manages my reminders, runs scheduled briefings, and automates browser tasks. Here&#39;s how it works." />
+  <meta name="twitter:title" content="I Built a Personal AI Assistant That Lives in Slack | Spicer Matthews" />
+  <meta name="twitter:description" content="I built Autumn, a personal AI assistant that lives in Slack and runs on Claude Code. Here&#39;s how a Go bot, a CLAUDE.md playbook, and cron jobs make it work." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/autumn-ai-assistant.png" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2026-01-30T10:00:00-07:00","datePublished":"2026-01-30T10:00:00-07:00","description":"I built Autumn, a personal AI assistant that lives in Slack and runs on Claude Code. Here's how a Go bot, a CLAUDE.md playbook, and cron jobs make it work.","headline":"I Built a Personal AI Assistant That Lives in Slack","image":["https://spicermatthews.com/images/autumn-ai-assistant.png"],"inLanguage":"en-US","keywords":"personal AI assistant in Slack, Claude Code personal assistant, CLAUDE.md playbook, build AI assistant with Claude Code, Claude Code Slack bot, AI assistant cron jobs, Playwright MCP browser automation, Go Slack bot Claude Code","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/i-built-a-personal-ai-assistant-that-lives-in-slack/","@type":"WebPage"},"name":"I Built a Personal AI Assistant That Lives in Slack","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/i-built-a-personal-ai-assistant-that-lives-in-slack/","wordCount":1374}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/i-built-a-personal-ai-assistant-that-lives-in-slack/","name":"I Built a Personal AI Assistant That Lives in Slack","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -455,6 +480,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/my-new-ai-first-development-workflow-github-issues/" class="block no-underline group">
+          <img src="/images/github-issues.png" alt="My New AI-First Development Workflow - Github Issues" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">My New AI-First Development Workflow - Github Issues</span>
+          <time class="block text-sm text-gray-500 mt-1">December 29, 2025</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/" class="block no-underline group">
+          <img src="/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png" alt="I Built a Tradier CLI Because AI Agents Deserve Better Tools" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Built a Tradier CLI Because AI Agents Deserve Better Tools</span>
+          <time class="block text-sm text-gray-500 mt-1">March 18, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/" class="block no-underline group">
+          <img src="/images/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.png" alt="I Vibe Coded a Screenshot Tool Because Claude Code Needed One" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Vibe Coded a Screenshot Tool Because Claude Code Needed One</span>
+          <time class="block text-sm text-gray-500 mt-1">February 24, 2026</time>
         </a>
       </div>
     </div>

--- a/docs/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/index.html
+++ b/docs/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>I Built a Tradier CLI Because AI Agents Deserve Better Tools</title>
-  <meta name="description" content="MCP servers flood your AI agent&#39;s context window with massive JSON payloads. A CLI gives it exactly what it needs. Here&#39;s why I built a full Tradier brokerage CLI in Go — and why CLIs are the better interface for AI-powered trading workflows." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="I Built a Tradier CLI Because AI Agents Deserve Better Tools" />
-  <meta property="og:description" content="MCP servers flood your AI agent&#39;s context window with massive JSON payloads. A CLI gives it exactly what it needs. Here&#39;s why I built a full Tradier brokerage CLI in Go — and why CLIs are the better interface for AI-powered trading workflows." />
+  <title>I Built a Tradier CLI Because AI Agents Deserve Better Tools | Spicer Matthews</title>
+  <meta name="description" content="I built a full Tradier brokerage CLI in Go so AI agents like Claude Code can trade without flooding the context window. Here is why CLIs beat MCP servers." />
+  <meta name="keywords" content="Tradier CLI, CLI vs MCP server for AI agents, AI agent trading tools, Claude Code brokerage automation, Tradier API command line, options trading CLI, CLI for AI agents, AI options trading workflow" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="I Built a Tradier CLI Because AI Agents Deserve Better Tools | Spicer Matthews" />
+  <meta property="og:description" content="I built a full Tradier brokerage CLI in Go so AI agents like Claude Code can trade without flooding the context window. Here is why CLIs beat MCP servers." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png" />
+  <meta property="og:image:alt" content="I Built a Tradier CLI Because AI Agents Deserve Better Tools" />
+  <meta property="article:published_time" content="2026-03-18T08:00:00-07:00" />
+  <meta property="article:modified_time" content="2026-03-18T08:00:00-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="Tradier CLI" />
+  <meta property="article:tag" content="CLI vs MCP server for AI agents" />
+  <meta property="article:tag" content="AI agent trading tools" />
+  <meta property="article:tag" content="Claude Code brokerage automation" />
+  <meta property="article:tag" content="Tradier API command line" />
+  <meta property="article:tag" content="options trading CLI" />
+  <meta property="article:tag" content="CLI for AI agents" />
+  <meta property="article:tag" content="AI options trading workflow" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="MCP servers flood your AI agent&#39;s context window with massive JSON payloads. A CLI gives it exactly what it needs. Here&#39;s why I built a full Tradier brokerage CLI in Go — and why CLIs are the better interface for AI-powered trading workflows." />
+  <meta name="twitter:title" content="I Built a Tradier CLI Because AI Agents Deserve Better Tools | Spicer Matthews" />
+  <meta name="twitter:description" content="I built a full Tradier brokerage CLI in Go so AI agents like Claude Code can trade without flooding the context window. Here is why CLIs beat MCP servers." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2026-03-18T08:00:00-07:00","datePublished":"2026-03-18T08:00:00-07:00","description":"I built a full Tradier brokerage CLI in Go so AI agents like Claude Code can trade without flooding the context window. Here is why CLIs beat MCP servers.","headline":"I Built a Tradier CLI Because AI Agents Deserve Better Tools","image":["https://spicermatthews.com/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png"],"inLanguage":"en-US","keywords":"Tradier CLI, CLI vs MCP server for AI agents, AI agent trading tools, Claude Code brokerage automation, Tradier API command line, options trading CLI, CLI for AI agents, AI options trading workflow","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/","@type":"WebPage"},"name":"I Built a Tradier CLI Because AI Agents Deserve Better Tools","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/","wordCount":1761}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/","name":"I Built a Tradier CLI Because AI Agents Deserve Better Tools","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -451,6 +476,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/why-i-built-a-cli-for-massive-financial-data/" class="block no-underline group">
+          <img src="/images/blog/massive-cli.jpg" alt="Why I Built a CLI for Massive Financial Data" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Why I Built a CLI for Massive Financial Data</span>
+          <time class="block text-sm text-gray-500 mt-1">February 16, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/full-circle-back-to-the-terminal/" class="block no-underline group">
+          <img src="/images/blog/full-circle-back-to-the-terminal.jpg" alt="Full Circle: Back to the Terminal" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Full Circle: Back to the Terminal</span>
+          <time class="block text-sm text-gray-500 mt-1">February 19, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/the-stock-market-is-a-drunken-idiot-you-should-profit-from-it/" class="block no-underline group">
+          <img src="/images/drunk-people-dancing.jpg" alt="The Stock Market Is a Drunken Idiot -- You Should Profit From It" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">The Stock Market Is a Drunken Idiot -- You Should Profit From It</span>
+          <time class="block text-sm text-gray-500 mt-1">February 24, 2023</time>
         </a>
       </div>
     </div>

--- a/docs/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/index.html
+++ b/docs/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>I Vibe Coded a Screenshot Tool Because Claude Code Needed One</title>
-  <meta name="description" content="I&#39;ve been living in the terminal with Claude Code, Neovim, and tmux. But sharing screenshots with an AI that lives in a terminal session? That was broken. So I vibe coded a macOS screenshot tool that uploads to S3 and gives me a direct URL. Problem solved." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="I Vibe Coded a Screenshot Tool Because Claude Code Needed One" />
-  <meta property="og:description" content="I&#39;ve been living in the terminal with Claude Code, Neovim, and tmux. But sharing screenshots with an AI that lives in a terminal session? That was broken. So I vibe coded a macOS screenshot tool that uploads to S3 and gives me a direct URL. Problem solved." />
+  <title>I Vibe Coded a Screenshot Tool Because Claude Code Needed One | Spicer Matthews</title>
+  <meta name="description" content="Sharing screenshots with Claude Code over SSH was broken, so I vibe coded a macOS menu bar app that uploads to S3 and drops a direct image URL on my clipboard." />
+  <meta name="keywords" content="share screenshots with Claude Code, macOS screenshot to S3 tool, Claude Code terminal SSH workflow, vibe coding a macOS app, screenshot direct image URL clipboard, Swift menu bar screenshot tool, AWS S3 pre-signed URL screenshot, open source screenshot tool for AI" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="I Vibe Coded a Screenshot Tool Because Claude Code Needed One | Spicer Matthews" />
+  <meta property="og:description" content="Sharing screenshots with Claude Code over SSH was broken, so I vibe coded a macOS menu bar app that uploads to S3 and drops a direct image URL on my clipboard." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.png" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.png" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.png" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.png" />
+  <meta property="og:image:alt" content="I Vibe Coded a Screenshot Tool Because Claude Code Needed One" />
+  <meta property="article:published_time" content="2026-02-24T12:00:00-07:00" />
+  <meta property="article:modified_time" content="2026-02-24T12:00:00-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="share screenshots with Claude Code" />
+  <meta property="article:tag" content="macOS screenshot to S3 tool" />
+  <meta property="article:tag" content="Claude Code terminal SSH workflow" />
+  <meta property="article:tag" content="vibe coding a macOS app" />
+  <meta property="article:tag" content="screenshot direct image URL clipboard" />
+  <meta property="article:tag" content="Swift menu bar screenshot tool" />
+  <meta property="article:tag" content="AWS S3 pre-signed URL screenshot" />
+  <meta property="article:tag" content="open source screenshot tool for AI" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.png" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="I&#39;ve been living in the terminal with Claude Code, Neovim, and tmux. But sharing screenshots with an AI that lives in a terminal session? That was broken. So I vibe coded a macOS screenshot tool that uploads to S3 and gives me a direct URL. Problem solved." />
+  <meta name="twitter:title" content="I Vibe Coded a Screenshot Tool Because Claude Code Needed One | Spicer Matthews" />
+  <meta name="twitter:description" content="Sharing screenshots with Claude Code over SSH was broken, so I vibe coded a macOS menu bar app that uploads to S3 and drops a direct image URL on my clipboard." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.png" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2026-02-24T12:00:00-07:00","datePublished":"2026-02-24T12:00:00-07:00","description":"Sharing screenshots with Claude Code over SSH was broken, so I vibe coded a macOS menu bar app that uploads to S3 and drops a direct image URL on my clipboard.","headline":"I Vibe Coded a Screenshot Tool Because Claude Code Needed One","image":["https://spicermatthews.com/images/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.png"],"inLanguage":"en-US","keywords":"share screenshots with Claude Code, macOS screenshot to S3 tool, Claude Code terminal SSH workflow, vibe coding a macOS app, screenshot direct image URL clipboard, Swift menu bar screenshot tool, AWS S3 pre-signed URL screenshot, open source screenshot tool for AI","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/","@type":"WebPage"},"name":"I Vibe Coded a Screenshot Tool Because Claude Code Needed One","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/","wordCount":1676}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/","name":"I Vibe Coded a Screenshot Tool Because Claude Code Needed One","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -431,6 +456,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/full-circle-back-to-the-terminal/" class="block no-underline group">
+          <img src="/images/blog/full-circle-back-to-the-terminal.jpg" alt="Full Circle: Back to the Terminal" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Full Circle: Back to the Terminal</span>
+          <time class="block text-sm text-gray-500 mt-1">February 19, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/" class="block no-underline group">
+          <img src="/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png" alt="I Built a Tradier CLI Because AI Agents Deserve Better Tools" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Built a Tradier CLI Because AI Agents Deserve Better Tools</span>
+          <time class="block text-sm text-gray-500 mt-1">March 18, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/my-new-ai-first-development-workflow-github-issues/" class="block no-underline group">
+          <img src="/images/github-issues.png" alt="My New AI-First Development Workflow - Github Issues" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">My New AI-First Development Workflow - Github Issues</span>
+          <time class="block text-sm text-gray-500 mt-1">December 29, 2025</time>
         </a>
       </div>
     </div>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -3,28 +3,41 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Blogs</title>
-  <meta name="description" content="" />
+
+  
+  <title>Blog | Spicer Matthews</title>
+  <meta name="description" content="Essays by Spicer Matthews on AI-first software development, building products, options trading, and entrepreneurship — lessons from 20&#43; years of shipping software." />
+  <meta name="keywords" content="Spicer Matthews blog, AI-first development, software development essays, options trading, building software products, indie hacking" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/" />
+
   <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
 
   
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="Blogs" />
-  <meta property="og:description" content="" />
+  <meta property="og:title" content="Blog | Spicer Matthews" />
+  <meta property="og:description" content="Essays by Spicer Matthews on AI-first software development, building products, options trading, and entrepreneurship — lessons from 20&#43; years of shipping software." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/" />
-  <meta property="og:locale" content="en" />
-
-  
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:alt" content="Blog" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-  
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="" />
+  <meta name="twitter:title" content="Blog | Spicer Matthews" />
+  <meta name="twitter:description" content="Essays by Spicer Matthews on AI-first software development, building products, options trading, and entrepreneurship — lessons from 20&#43; years of shipping software." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","description":"Essays by Spicer Matthews on AI-first software development, building products, options trading, and entrepreneurship — lessons from 20+ years of shipping software.","inLanguage":"en-US","isPartOf":{"@id":"https://spicermatthews.com/#website"},"name":"Blog","url":"https://spicermatthews.com/blog/"}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -116,7 +129,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">I went full circle back to the terminal, but Vim never quite fit. So I vibe coded SpiceEdit — a mouse-first terminal code editor for engineers who live in tmux and SSH, without a four-thousand-line vimrc. One Go binary. MIT licensed. Free forever.</p>
+            <p class="text-gray-600 my-0">I vibe coded SpiceEdit, a mouse-first terminal code editor for AI-era devs who live in tmux and SSH. One Go binary, no vimrc, MIT licensed, free forever.</p>
             
             <a href="https://spicermatthews.com/blog/introducing-spice-edit/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -145,7 +158,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">For 15 years I had a CPA I trusted. She worked from home, we did almost everything by email, and tax season felt manageable. Since she retired I&#39;ve been trying to find that same relationship — digital-first, responsive, and organized — and I haven&#39;t. Here&#39;s what I&#39;m looking for.</p>
+            <p class="text-gray-600 my-0">For 15 years I had a digital-first CPA I trusted. Since she retired I can&#39;t find a responsive, organized replacement. Here&#39;s exactly what I&#39;m looking for.</p>
             
             <a href="https://spicermatthews.com/blog/looking-for-a-new-cpa/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -174,7 +187,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">MCP servers flood your AI agent&#39;s context window with massive JSON payloads. A CLI gives it exactly what it needs. Here&#39;s why I built a full Tradier brokerage CLI in Go — and why CLIs are the better interface for AI-powered trading workflows.</p>
+            <p class="text-gray-600 my-0">I built a full Tradier brokerage CLI in Go so AI agents like Claude Code can trade without flooding the context window. Here is why CLIs beat MCP servers.</p>
             
             <a href="https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -203,7 +216,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">I&#39;ve been living in the terminal with Claude Code, Neovim, and tmux. But sharing screenshots with an AI that lives in a terminal session? That was broken. So I vibe coded a macOS screenshot tool that uploads to S3 and gives me a direct URL. Problem solved.</p>
+            <p class="text-gray-600 my-0">Sharing screenshots with Claude Code over SSH was broken, so I vibe coded a macOS menu bar app that uploads to S3 and drops a direct image URL on my clipboard.</p>
             
             <a href="https://spicermatthews.com/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -232,7 +245,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">I started my career in the late 90s doing everything in the terminal. Over 30 years I migrated to GUIs, web apps, and desktop tools. Now, thanks to Claude Code, Neovim, and tmux, I&#39;m back where I started — and it&#39;s never felt better.</p>
+            <p class="text-gray-600 my-0">After 30 years in GUIs, I&#39;m back in the terminal full-time with Claude Code, Neovim, and tmux. Here&#39;s my development workflow and why it feels like home.</p>
             
             <a href="https://spicermatthews.com/blog/full-circle-back-to-the-terminal/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -261,7 +274,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">MCP servers flood your AI agent&#39;s context window. A CLI doesn&#39;t. I built Massive CLI — a command-line tool for the Massive financial data API — because a single binary that outputs clean tables or JSON is a better fit for both humans and AI agents.</p>
+            <p class="text-gray-600 my-0">MCP servers flood your AI agent&#39;s context window. So I built Massive CLI, a command-line tool for the Massive financial data API that outputs clean tables or JSON.</p>
             
             <a href="https://spicermatthews.com/blog/why-i-built-a-cli-for-massive-financial-data/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -290,7 +303,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">The most underrated career strategy isn&#39;t optimizing for ROI — it&#39;s just doing stuff. Putting things into the world consistently, without overthinking the return, has generated hundreds of thousands of dollars in opportunities over 20 years.</p>
+            <p class="text-gray-600 my-0">For 20 years I&#39;ve &#34;just done stuff&#34; — publishing without calculating ROI. That handful of posts quietly generated hundreds of thousands of dollars.</p>
             
             <a href="https://spicermatthews.com/blog/just-do-stuff/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -319,7 +332,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">Inspired by OpenClaw, I built Autumn — a personal AI assistant powered by Claude Code that lives in Slack. It reads my emails, manages my reminders, runs scheduled briefings, and automates browser tasks. Here&#39;s how it works.</p>
+            <p class="text-gray-600 my-0">I built Autumn, a personal AI assistant that lives in Slack and runs on Claude Code. Here&#39;s how a Go bot, a CLAUDE.md playbook, and cron jobs make it work.</p>
             
             <a href="https://spicermatthews.com/blog/i-built-a-personal-ai-assistant-that-lives-in-slack/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -348,7 +361,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">Getting 1,000 customers is brutal. But 100 customers at $200/month? That&#39;s $240k/year—and easier than you think. Here&#39;s why fewer customers means more profit.</p>
+            <p class="text-gray-600 my-0">I&#39;ve started multiple SaaS products, and getting 1,000 customers crushes most founders. Here&#39;s why 100 customers at $200/month is the smarter path to $100k profit.</p>
             
             <a href="https://spicermatthews.com/blog/why-100-customers-at-200-beats-1000-at-20/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -377,7 +390,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">Most of us don&#39;t need more hours in the day—we need systems that protect our attention and reduce friction. Here&#39;s how small changes compound into a life spent on what actually matters.</p>
+            <p class="text-gray-600 my-0">I don&#39;t need more hours in the day, and neither do you. Here&#39;s how I build systems that protect my attention, reduce friction, and compound into real time.</p>
             
             <a href="https://spicermatthews.com/blog/you-dont-lack-time-you-lack-a-system/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more

--- a/docs/blog/index.xml
+++ b/docs/blog/index.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>Blogs on Spicer Matthews Personal Site</title>
+    <title>Blog on Spicer Matthews Personal Site</title>
     <link>https://spicermatthews.com/blog/</link>
-    <description>Recent content in Blogs on Spicer Matthews Personal Site</description>
+    <description>Recent content in Blog on Spicer Matthews Personal Site</description>
     <generator>Hugo</generator>
     <language>en-us</language>
     <lastBuildDate>Thu, 30 Apr 2026 12:00:00 -0700</lastBuildDate>
@@ -142,7 +142,7 @@
       <description>Have you ever noticed that when someone drinks too much, they become predictable? They might start talking louder or acting crazier than usual. It&#39;s as if the alcohol has unlocked a different side of their personality. Most people are pretty steady and predictable creatures when they&#39;re sober, but when they get drunk, all bets are off. The same can be said for the stock market. Sometimes, stocks in the stock market behave like they&#39;re drunk.</description>
     </item>
     <item>
-      <title>Am Over Vendors That Are Not Transparent in Pricing</title>
+      <title>I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing</title>
       <link>https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/</link>
       <pubDate>Tue, 21 Apr 2020 20:18:58 -0700</pubDate>
       <guid>https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/</guid>

--- a/docs/blog/introducing-spice-edit/index.html
+++ b/docs/blog/introducing-spice-edit/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Introducing SpiceEdit: The Mouse-First Terminal Editor for the AI Era</title>
-  <meta name="description" content="I went full circle back to the terminal, but Vim never quite fit. So I vibe coded SpiceEdit — a mouse-first terminal code editor for engineers who live in tmux and SSH, without a four-thousand-line vimrc. One Go binary. MIT licensed. Free forever." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Introducing SpiceEdit: The Mouse-First Terminal Editor for the AI Era" />
-  <meta property="og:description" content="I went full circle back to the terminal, but Vim never quite fit. So I vibe coded SpiceEdit — a mouse-first terminal code editor for engineers who live in tmux and SSH, without a four-thousand-line vimrc. One Go binary. MIT licensed. Free forever." />
+  <title>Introducing SpiceEdit: The Mouse-First Terminal Editor for the AI Era | Spicer Matthews</title>
+  <meta name="description" content="I vibe coded SpiceEdit, a mouse-first terminal code editor for AI-era devs who live in tmux and SSH. One Go binary, no vimrc, MIT licensed, free forever." />
+  <meta name="keywords" content="mouse-first terminal code editor, terminal code editor for AI workflow, Vim alternative terminal editor, Go terminal editor single binary, SpiceEdit editor, best terminal editor for tmux and SSH, easy terminal editor instead of Neovim, OSC 52 SSH clipboard editor" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/introducing-spice-edit/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Introducing SpiceEdit: The Mouse-First Terminal Editor for the AI Era | Spicer Matthews" />
+  <meta property="og:description" content="I vibe coded SpiceEdit, a mouse-first terminal code editor for AI-era devs who live in tmux and SSH. One Go binary, no vimrc, MIT licensed, free forever." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/introducing-spice-edit/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/blog/introducing-spice-edit.png" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/introducing-spice-edit.png" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/blog/introducing-spice-edit.png" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/introducing-spice-edit.png" />
+  <meta property="og:image:alt" content="Introducing SpiceEdit: The Mouse-First Terminal Editor for the AI Era" />
+  <meta property="article:published_time" content="2026-04-30T12:00:00-07:00" />
+  <meta property="article:modified_time" content="2026-04-30T12:00:00-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="mouse-first terminal code editor" />
+  <meta property="article:tag" content="terminal code editor for AI workflow" />
+  <meta property="article:tag" content="Vim alternative terminal editor" />
+  <meta property="article:tag" content="Go terminal editor single binary" />
+  <meta property="article:tag" content="SpiceEdit editor" />
+  <meta property="article:tag" content="best terminal editor for tmux and SSH" />
+  <meta property="article:tag" content="easy terminal editor instead of Neovim" />
+  <meta property="article:tag" content="OSC 52 SSH clipboard editor" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/blog/introducing-spice-edit.png" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="I went full circle back to the terminal, but Vim never quite fit. So I vibe coded SpiceEdit — a mouse-first terminal code editor for engineers who live in tmux and SSH, without a four-thousand-line vimrc. One Go binary. MIT licensed. Free forever." />
+  <meta name="twitter:title" content="Introducing SpiceEdit: The Mouse-First Terminal Editor for the AI Era | Spicer Matthews" />
+  <meta name="twitter:description" content="I vibe coded SpiceEdit, a mouse-first terminal code editor for AI-era devs who live in tmux and SSH. One Go binary, no vimrc, MIT licensed, free forever." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/blog/introducing-spice-edit.png" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2026-04-30T12:00:00-07:00","datePublished":"2026-04-30T12:00:00-07:00","description":"I vibe coded SpiceEdit, a mouse-first terminal code editor for AI-era devs who live in tmux and SSH. One Go binary, no vimrc, MIT licensed, free forever.","headline":"Introducing SpiceEdit: The Mouse-First Terminal Editor for the AI Era","image":["https://spicermatthews.com/images/blog/introducing-spice-edit.png"],"inLanguage":"en-US","keywords":"mouse-first terminal code editor, terminal code editor for AI workflow, Vim alternative terminal editor, Go terminal editor single binary, SpiceEdit editor, best terminal editor for tmux and SSH, easy terminal editor instead of Neovim, OSC 52 SSH clipboard editor","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/introducing-spice-edit/","@type":"WebPage"},"name":"Introducing SpiceEdit: The Mouse-First Terminal Editor for the AI Era","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/introducing-spice-edit/","wordCount":1434}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/introducing-spice-edit/","name":"Introducing SpiceEdit: The Mouse-First Terminal Editor for the AI Era","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -383,6 +408,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/full-circle-back-to-the-terminal/" class="block no-underline group">
+          <img src="/images/blog/full-circle-back-to-the-terminal.jpg" alt="Full Circle: Back to the Terminal" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Full Circle: Back to the Terminal</span>
+          <time class="block text-sm text-gray-500 mt-1">February 19, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/" class="block no-underline group">
+          <img src="/images/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.png" alt="I Vibe Coded a Screenshot Tool Because Claude Code Needed One" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Vibe Coded a Screenshot Tool Because Claude Code Needed One</span>
+          <time class="block text-sm text-gray-500 mt-1">February 24, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/" class="block no-underline group">
+          <img src="/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png" alt="I Built a Tradier CLI Because AI Agents Deserve Better Tools" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Built a Tradier CLI Because AI Agents Deserve Better Tools</span>
+          <time class="block text-sm text-gray-500 mt-1">March 18, 2026</time>
         </a>
       </div>
     </div>

--- a/docs/blog/just-do-stuff/index.html
+++ b/docs/blog/just-do-stuff/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Just Do Stuff</title>
-  <meta name="description" content="The most underrated career strategy isn&#39;t optimizing for ROI — it&#39;s just doing stuff. Putting things into the world consistently, without overthinking the return, has generated hundreds of thousands of dollars in opportunities over 20 years." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Just Do Stuff" />
-  <meta property="og:description" content="The most underrated career strategy isn&#39;t optimizing for ROI — it&#39;s just doing stuff. Putting things into the world consistently, without overthinking the return, has generated hundreds of thousands of dollars in opportunities over 20 years." />
+  <title>Just Do Stuff | Spicer Matthews</title>
+  <meta name="description" content="For 20 years I&#39;ve &#34;just done stuff&#34; — publishing without calculating ROI. That handful of posts quietly generated hundreds of thousands of dollars." />
+  <meta name="keywords" content="just do stuff career strategy, you can just do things, how blogging leads to business opportunities, publishing your work increases your luck, building in public for developers, why blog with low traffic, creating luck surface area, consistency over optimization" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/just-do-stuff/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Just Do Stuff | Spicer Matthews" />
+  <meta property="og:description" content="For 20 years I&#39;ve &#34;just done stuff&#34; — publishing without calculating ROI. That handful of posts quietly generated hundreds of thousands of dollars." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/just-do-stuff/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/blog/just-do-stuff.jpg" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/just-do-stuff.jpg" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/blog/just-do-stuff.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/just-do-stuff.jpg" />
+  <meta property="og:image:alt" content="Just Do Stuff" />
+  <meta property="article:published_time" content="2026-02-03T12:00:00-07:00" />
+  <meta property="article:modified_time" content="2026-02-03T12:00:00-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="just do stuff career strategy" />
+  <meta property="article:tag" content="you can just do things" />
+  <meta property="article:tag" content="how blogging leads to business opportunities" />
+  <meta property="article:tag" content="publishing your work increases your luck" />
+  <meta property="article:tag" content="building in public for developers" />
+  <meta property="article:tag" content="why blog with low traffic" />
+  <meta property="article:tag" content="creating luck surface area" />
+  <meta property="article:tag" content="consistency over optimization" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/blog/just-do-stuff.jpg" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="The most underrated career strategy isn&#39;t optimizing for ROI — it&#39;s just doing stuff. Putting things into the world consistently, without overthinking the return, has generated hundreds of thousands of dollars in opportunities over 20 years." />
+  <meta name="twitter:title" content="Just Do Stuff | Spicer Matthews" />
+  <meta name="twitter:description" content="For 20 years I&#39;ve &#34;just done stuff&#34; — publishing without calculating ROI. That handful of posts quietly generated hundreds of thousands of dollars." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/blog/just-do-stuff.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2026-02-03T12:00:00-07:00","datePublished":"2026-02-03T12:00:00-07:00","description":"For 20 years I've \"just done stuff\" — publishing without calculating ROI. That handful of posts quietly generated hundreds of thousands of dollars.","headline":"Just Do Stuff","image":["https://spicermatthews.com/images/blog/just-do-stuff.jpg"],"inLanguage":"en-US","keywords":"just do stuff career strategy, you can just do things, how blogging leads to business opportunities, publishing your work increases your luck, building in public for developers, why blog with low traffic, creating luck surface area, consistency over optimization","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/just-do-stuff/","@type":"WebPage"},"name":"Just Do Stuff","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/just-do-stuff/","wordCount":1410}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/just-do-stuff/","name":"Just Do Stuff","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -396,6 +421,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more/" class="block no-underline group">
+          <img src="/images/spicer-matthews-wine-drinking.jpg" alt="Hello World: My New Blog, Hugo, Tailwind CSS, and More" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Hello World: My New Blog, Hugo, Tailwind CSS, and More</span>
+          <time class="block text-sm text-gray-500 mt-1">July 17, 2019</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/the-ai-side-hustle-revolution-turning-niche-ideas-into-income/" class="block no-underline group">
+          <img src="/images/ai-side-hustle-coding.jpg" alt="The AI Side Hustle Revolution: Turning Niche Ideas into Income" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">The AI Side Hustle Revolution: Turning Niche Ideas into Income</span>
+          <time class="block text-sm text-gray-500 mt-1">June 6, 2025</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/you-dont-lack-time-you-lack-a-system/" class="block no-underline group">
+          <img src="/images/system.png" alt="You Don&#39;t Lack Time. You Lack a System." class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">You Don&#39;t Lack Time. You Lack a System.</span>
+          <time class="block text-sm text-gray-500 mt-1">January 13, 2026</time>
         </a>
       </div>
     </div>

--- a/docs/blog/looking-for-a-new-cpa/index.html
+++ b/docs/blog/looking-for-a-new-cpa/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>I&#39;m Looking for a New CPA</title>
-  <meta name="description" content="For 15 years I had a CPA I trusted. She worked from home, we did almost everything by email, and tax season felt manageable. Since she retired I&#39;ve been trying to find that same relationship — digital-first, responsive, and organized — and I haven&#39;t. Here&#39;s what I&#39;m looking for." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="I&#39;m Looking for a New CPA" />
-  <meta property="og:description" content="For 15 years I had a CPA I trusted. She worked from home, we did almost everything by email, and tax season felt manageable. Since she retired I&#39;ve been trying to find that same relationship — digital-first, responsive, and organized — and I haven&#39;t. Here&#39;s what I&#39;m looking for." />
+  <title>I&#39;m Looking for a New CPA | Spicer Matthews</title>
+  <meta name="description" content="For 15 years I had a digital-first CPA I trusted. Since she retired I can&#39;t find a responsive, organized replacement. Here&#39;s exactly what I&#39;m looking for." />
+  <meta name="keywords" content="looking for a new CPA, digital-first CPA, CPA who works by email, finding a responsive CPA, CPA for complex taxes, asynchronous CPA communication, CPA in the age of AI, remote CPA for tax preparation" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/looking-for-a-new-cpa/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="I&#39;m Looking for a New CPA | Spicer Matthews" />
+  <meta property="og:description" content="For 15 years I had a digital-first CPA I trusted. Since she retired I can&#39;t find a responsive, organized replacement. Here&#39;s exactly what I&#39;m looking for." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/looking-for-a-new-cpa/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/blog/looking-for-a-new-cpa.jpg" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/looking-for-a-new-cpa.jpg" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/blog/looking-for-a-new-cpa.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/looking-for-a-new-cpa.jpg" />
+  <meta property="og:image:alt" content="I&#39;m Looking for a New CPA" />
+  <meta property="article:published_time" content="2026-04-20T08:00:00-07:00" />
+  <meta property="article:modified_time" content="2026-04-20T08:00:00-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="looking for a new CPA" />
+  <meta property="article:tag" content="digital-first CPA" />
+  <meta property="article:tag" content="CPA who works by email" />
+  <meta property="article:tag" content="finding a responsive CPA" />
+  <meta property="article:tag" content="CPA for complex taxes" />
+  <meta property="article:tag" content="asynchronous CPA communication" />
+  <meta property="article:tag" content="CPA in the age of AI" />
+  <meta property="article:tag" content="remote CPA for tax preparation" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/blog/looking-for-a-new-cpa.jpg" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="For 15 years I had a CPA I trusted. She worked from home, we did almost everything by email, and tax season felt manageable. Since she retired I&#39;ve been trying to find that same relationship — digital-first, responsive, and organized — and I haven&#39;t. Here&#39;s what I&#39;m looking for." />
+  <meta name="twitter:title" content="I&#39;m Looking for a New CPA | Spicer Matthews" />
+  <meta name="twitter:description" content="For 15 years I had a digital-first CPA I trusted. Since she retired I can&#39;t find a responsive, organized replacement. Here&#39;s exactly what I&#39;m looking for." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/blog/looking-for-a-new-cpa.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2026-04-20T08:00:00-07:00","datePublished":"2026-04-20T08:00:00-07:00","description":"For 15 years I had a digital-first CPA I trusted. Since she retired I can't find a responsive, organized replacement. Here's exactly what I'm looking for.","headline":"I'm Looking for a New CPA","image":["https://spicermatthews.com/images/blog/looking-for-a-new-cpa.jpg"],"inLanguage":"en-US","keywords":"looking for a new CPA, digital-first CPA, CPA who works by email, finding a responsive CPA, CPA for complex taxes, asynchronous CPA communication, CPA in the age of AI, remote CPA for tax preparation","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/looking-for-a-new-cpa/","@type":"WebPage"},"name":"I'm Looking for a New CPA","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/looking-for-a-new-cpa/","wordCount":1555}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/looking-for-a-new-cpa/","name":"I'm Looking for a New CPA","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -432,6 +457,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/" class="block no-underline group">
+          <img src="/images/vendor-sales-person.png" alt="I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing</span>
+          <time class="block text-sm text-gray-500 mt-1">April 21, 2020</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/i-built-a-personal-ai-assistant-that-lives-in-slack/" class="block no-underline group">
+          <img src="/images/autumn-ai-assistant.png" alt="I Built a Personal AI Assistant That Lives in Slack" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Built a Personal AI Assistant That Lives in Slack</span>
+          <time class="block text-sm text-gray-500 mt-1">January 30, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/why-100-customers-at-200-beats-1000-at-20/" class="block no-underline group">
+          <img src="/images/200-month.jpg" alt="Why 100 Customers at $200 Beats 1,000 at $20" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Why 100 Customers at $200 Beats 1,000 at $20</span>
+          <time class="block text-sm text-gray-500 mt-1">January 19, 2026</time>
         </a>
       </div>
     </div>

--- a/docs/blog/my-new-ai-first-development-workflow-github-issues/index.html
+++ b/docs/blog/my-new-ai-first-development-workflow-github-issues/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>My New AI-First Development Workflow - Github Issues</title>
-  <meta name="description" content="How I transformed my development workflow by treating GitHub Issues as both my project management system and planning document, with Claude at the command line as my primary collaborator." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="My New AI-First Development Workflow - Github Issues" />
-  <meta property="og:description" content="How I transformed my development workflow by treating GitHub Issues as both my project management system and planning document, with Claude at the command line as my primary collaborator." />
+  <title>My New AI-First Development Workflow - Github Issues | Spicer Matthews</title>
+  <meta name="description" content="Here&#39;s how I rebuilt my dev workflow around GitHub Issues as planning docs and Claude at the command line to scope, build, and ship code with far less overhead." />
+  <meta name="keywords" content="AI-first development workflow with GitHub Issues, GitHub Issues as planning documents, Claude Code CLI development workflow, using GitHub CLI with AI agents, GitHub Issues vs Jira and Asana, why I don&#39;t use MCP servers, AI coding workflow for developers, turn GitHub issues into pull requests with AI" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/my-new-ai-first-development-workflow-github-issues/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="My New AI-First Development Workflow - Github Issues | Spicer Matthews" />
+  <meta property="og:description" content="Here&#39;s how I rebuilt my dev workflow around GitHub Issues as planning docs and Claude at the command line to scope, build, and ship code with far less overhead." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/my-new-ai-first-development-workflow-github-issues/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/github-issues.png" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/github-issues.png" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/github-issues.png" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/github-issues.png" />
+  <meta property="og:image:alt" content="My New AI-First Development Workflow - Github Issues" />
+  <meta property="article:published_time" content="2025-12-29T10:00:00-07:00" />
+  <meta property="article:modified_time" content="2025-12-29T10:00:00-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="AI-first development workflow with GitHub Issues" />
+  <meta property="article:tag" content="GitHub Issues as planning documents" />
+  <meta property="article:tag" content="Claude Code CLI development workflow" />
+  <meta property="article:tag" content="using GitHub CLI with AI agents" />
+  <meta property="article:tag" content="GitHub Issues vs Jira and Asana" />
+  <meta property="article:tag" content="why I don&#39;t use MCP servers" />
+  <meta property="article:tag" content="AI coding workflow for developers" />
+  <meta property="article:tag" content="turn GitHub issues into pull requests with AI" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/github-issues.png" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="How I transformed my development workflow by treating GitHub Issues as both my project management system and planning document, with Claude at the command line as my primary collaborator." />
+  <meta name="twitter:title" content="My New AI-First Development Workflow - Github Issues | Spicer Matthews" />
+  <meta name="twitter:description" content="Here&#39;s how I rebuilt my dev workflow around GitHub Issues as planning docs and Claude at the command line to scope, build, and ship code with far less overhead." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/github-issues.png" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2025-12-29T10:00:00-07:00","datePublished":"2025-12-29T10:00:00-07:00","description":"Here's how I rebuilt my dev workflow around GitHub Issues as planning docs and Claude at the command line to scope, build, and ship code with far less overhead.","headline":"My New AI-First Development Workflow - Github Issues","image":["https://spicermatthews.com/images/github-issues.png"],"inLanguage":"en-US","keywords":"AI-first development workflow with GitHub Issues, GitHub Issues as planning documents, Claude Code CLI development workflow, using GitHub CLI with AI agents, GitHub Issues vs Jira and Asana, why I don't use MCP servers, AI coding workflow for developers, turn GitHub issues into pull requests with AI","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/my-new-ai-first-development-workflow-github-issues/","@type":"WebPage"},"name":"My New AI-First Development Workflow - Github Issues","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/my-new-ai-first-development-workflow-github-issues/","wordCount":1202}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/my-new-ai-first-development-workflow-github-issues/","name":"My New AI-First Development Workflow - Github Issues","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -677,6 +702,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/" class="block no-underline group">
+          <img src="/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png" alt="I Built a Tradier CLI Because AI Agents Deserve Better Tools" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Built a Tradier CLI Because AI Agents Deserve Better Tools</span>
+          <time class="block text-sm text-gray-500 mt-1">March 18, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/" class="block no-underline group">
+          <img src="/images/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.png" alt="I Vibe Coded a Screenshot Tool Because Claude Code Needed One" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Vibe Coded a Screenshot Tool Because Claude Code Needed One</span>
+          <time class="block text-sm text-gray-500 mt-1">February 24, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/full-circle-back-to-the-terminal/" class="block no-underline group">
+          <img src="/images/blog/full-circle-back-to-the-terminal.jpg" alt="Full Circle: Back to the Terminal" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Full Circle: Back to the Terminal</span>
+          <time class="block text-sm text-gray-500 mt-1">February 19, 2026</time>
         </a>
       </div>
     </div>

--- a/docs/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit/index.html
+++ b/docs/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Nitpicking Code Quality: A Necessary Evil or a Harmful Habit?</title>
-  <meta name="description" content="While Frank and I would agree on almost every software development principle in a perfect world, for me, the perfect world comes at a cost that I don&#39;t believe is worth it for most projects." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Nitpicking Code Quality: A Necessary Evil or a Harmful Habit?" />
-  <meta property="og:description" content="While Frank and I would agree on almost every software development principle in a perfect world, for me, the perfect world comes at a cost that I don&#39;t believe is worth it for most projects." />
+  <title>Nitpicking Code Quality: A Necessary Evil or a Harmful Habit? | Spicer Matthews</title>
+  <meta name="description" content="I think nitpicking in code reviews kills developer motivation. Here&#39;s why blocking PRs over style issues costs small teams more than it ever saves." />
+  <meta name="keywords" content="nitpicking in code reviews, code review nitpicks, pull request nitpicking, code quality vs developer motivation, blocking PRs over style issues, code review culture at small companies, big tech vs startup engineering culture, keeping developers in flow" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Nitpicking Code Quality: A Necessary Evil or a Harmful Habit? | Spicer Matthews" />
+  <meta property="og:description" content="I think nitpicking in code reviews kills developer motivation. Here&#39;s why blocking PRs over style issues costs small teams more than it ever saves." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/computer-code.jpg" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/computer-code.jpg" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/computer-code.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/computer-code.jpg" />
+  <meta property="og:image:alt" content="Nitpicking Code Quality: A Necessary Evil or a Harmful Habit?" />
+  <meta property="article:published_time" content="2023-03-22T13:18:58-07:00" />
+  <meta property="article:modified_time" content="2023-03-22T13:18:58-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="nitpicking in code reviews" />
+  <meta property="article:tag" content="code review nitpicks" />
+  <meta property="article:tag" content="pull request nitpicking" />
+  <meta property="article:tag" content="code quality vs developer motivation" />
+  <meta property="article:tag" content="blocking PRs over style issues" />
+  <meta property="article:tag" content="code review culture at small companies" />
+  <meta property="article:tag" content="big tech vs startup engineering culture" />
+  <meta property="article:tag" content="keeping developers in flow" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/computer-code.jpg" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="While Frank and I would agree on almost every software development principle in a perfect world, for me, the perfect world comes at a cost that I don&#39;t believe is worth it for most projects." />
+  <meta name="twitter:title" content="Nitpicking Code Quality: A Necessary Evil or a Harmful Habit? | Spicer Matthews" />
+  <meta name="twitter:description" content="I think nitpicking in code reviews kills developer motivation. Here&#39;s why blocking PRs over style issues costs small teams more than it ever saves." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/computer-code.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2023-03-22T13:18:58-07:00","datePublished":"2023-03-22T13:18:58-07:00","description":"I think nitpicking in code reviews kills developer motivation. Here's why blocking PRs over style issues costs small teams more than it ever saves.","headline":"Nitpicking Code Quality: A Necessary Evil or a Harmful Habit?","image":["https://spicermatthews.com/images/computer-code.jpg"],"inLanguage":"en-US","keywords":"nitpicking in code reviews, code review nitpicks, pull request nitpicking, code quality vs developer motivation, blocking PRs over style issues, code review culture at small companies, big tech vs startup engineering culture, keeping developers in flow","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit/","@type":"WebPage"},"name":"Nitpicking Code Quality: A Necessary Evil or a Harmful Habit?","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit/","wordCount":674}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit/","name":"Nitpicking Code Quality: A Necessary Evil or a Harmful Habit?","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -234,6 +259,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/streamlining-code-reviews-maximize-efficiency-and-effectiveness/" class="block no-underline group">
+          <img src="/images/code-review.jpg" alt="Streamlining Code Reviews: Maximize Efficiency and Effectiveness" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Streamlining Code Reviews: Maximize Efficiency and Effectiveness</span>
+          <time class="block text-sm text-gray-500 mt-1">March 30, 2023</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/spicers-rules-on-how-and-when-to-test-your-code/" class="block no-underline group">
+          <img src="/images/talk-code-to-me.png" alt="Spicer&#39;s Rules on How and When To Test Your Code" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Spicer&#39;s Rules on How and When To Test Your Code</span>
+          <time class="block text-sm text-gray-500 mt-1">September 15, 2019</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/prioritizing-tdd-friendly-languages-and-frameworks/" class="block no-underline group">
+          <img src="/images/computer-code.jpg" alt="Prioritizing TDD Friendly Languages and Frameworks" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Prioritizing TDD Friendly Languages and Frameworks</span>
+          <time class="block text-sm text-gray-500 mt-1">March 18, 2023</time>
         </a>
       </div>
     </div>

--- a/docs/blog/page/2/index.html
+++ b/docs/blog/page/2/index.html
@@ -3,28 +3,41 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Blogs</title>
-  <meta name="description" content="" />
+
+  
+  <title>Blog | Spicer Matthews</title>
+  <meta name="description" content="Essays by Spicer Matthews on AI-first software development, building products, options trading, and entrepreneurship — lessons from 20&#43; years of shipping software." />
+  <meta name="keywords" content="Spicer Matthews blog, AI-first development, software development essays, options trading, building software products, indie hacking" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/" />
+
   <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
 
   
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="Blogs" />
-  <meta property="og:description" content="" />
+  <meta property="og:title" content="Blog | Spicer Matthews" />
+  <meta property="og:description" content="Essays by Spicer Matthews on AI-first software development, building products, options trading, and entrepreneurship — lessons from 20&#43; years of shipping software." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/" />
-  <meta property="og:locale" content="en" />
-
-  
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:alt" content="Blog" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-  
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="" />
+  <meta name="twitter:title" content="Blog | Spicer Matthews" />
+  <meta name="twitter:description" content="Essays by Spicer Matthews on AI-first software development, building products, options trading, and entrepreneurship — lessons from 20&#43; years of shipping software." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","description":"Essays by Spicer Matthews on AI-first software development, building products, options trading, and entrepreneurship — lessons from 20+ years of shipping software.","inLanguage":"en-US","isPartOf":{"@id":"https://spicermatthews.com/#website"},"name":"Blog","url":"https://spicermatthews.com/blog/"}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -116,7 +129,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">How I transformed my development workflow by treating GitHub Issues as both my project management system and planning document, with Claude at the command line as my primary collaborator.</p>
+            <p class="text-gray-600 my-0">Here&#39;s how I rebuilt my dev workflow around GitHub Issues as planning docs and Claude at the command line to scope, build, and ship code with far less overhead.</p>
             
             <a href="https://spicermatthews.com/blog/my-new-ai-first-development-workflow-github-issues/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -145,7 +158,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">How a 2,000-square-foot remodel showed me just how broken, wasteful, and middleman-heavy the construction industry has become—and why I’m rooting for robots to take over.</p>
+            <p class="text-gray-600 my-0">I got $300K&#43; bids to remodel my home, then did it myself as GC for under $100K. Here&#39;s where construction money really goes, and why I want robots building houses.</p>
             
             <a href="https://spicermatthews.com/blog/remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -174,7 +187,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">After two decades as a hobbyist builder, I&#39;ve learned to spot when contractors are pricing the job—or pricing the lifestyle. Here&#39;s how to protect your budget and get fair quotes.</p>
+            <p class="text-gray-600 my-0">After two decades of building, I learned to spot inflated contractor bids and price-gouging. Here&#39;s how I get fair quotes and protect my renovation budget.</p>
             
             <a href="https://spicermatthews.com/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -203,7 +216,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">How AI tools like Claude and GitHub Copilot enabled me to build OregonPastDueRent.com in under 80 hours and $1000, proving that niche software ideas are now profitable side hustles for developers.</p>
+            <p class="text-gray-600 my-0">I built OregonPastDueRent.com in under 80 hours and $1000 using Claude and GitHub Copilot. Here&#39;s why AI makes niche software a real side hustle for developers.</p>
             
             <a href="https://spicermatthews.com/blog/the-ai-side-hustle-revolution-turning-niche-ideas-into-income/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -232,7 +245,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">Exploring the need for excellence over barriers in real estate, advocating for innovation and fairness in the industry.</p>
+            <p class="text-gray-600 my-0">After 50&#43; real estate deals, I argue the NAR commission settlement should push the industry to compete on excellence, not moats like MLS control.</p>
             
             <a href="https://spicermatthews.com/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -261,7 +274,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">Rethinking code reviews: balance efficiency &amp; impact, encourage developer discretion, prioritize robust QA workflow, and consider AI-driven solutions.</p>
+            <p class="text-gray-600 my-0">After years on different teams, here is my contrarian take on code reviews: make pull requests developer discretion, lean on QA, and let AI help.</p>
             
             <a href="https://spicermatthews.com/blog/streamlining-code-reviews-maximize-efficiency-and-effectiveness/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -290,7 +303,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">While Frank and I would agree on almost every software development principle in a perfect world, for me, the perfect world comes at a cost that I don&#39;t believe is worth it for most projects.</p>
+            <p class="text-gray-600 my-0">I think nitpicking in code reviews kills developer motivation. Here&#39;s why blocking PRs over style issues costs small teams more than it ever saves.</p>
             
             <a href="https://spicermatthews.com/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -319,6 +332,8 @@
               </a>
             </h2>
             
+            <p class="text-gray-600 my-0">I pick TDD friendly languages and frameworks like Go and PHP over hard-to-test options like Node.js, and here&#39;s why testing should speed you up, not slow you down.</p>
+            
             <a href="https://spicermatthews.com/blog/prioritizing-tdd-friendly-languages-and-frameworks/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
               <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -346,6 +361,8 @@
               </a>
             </h2>
             
+            <p class="text-gray-600 my-0">I treat erratic stocks like drunk people: loud, volatile, and surprisingly predictable. Here&#39;s how I spot volatile stocks and swing trade the chaos for profit.</p>
+            
             <a href="https://spicermatthews.com/blog/the-stock-market-is-a-drunken-idiot-you-should-profit-from-it/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
               <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -361,7 +378,7 @@
           
           <div class="md:flex-shrink-0">
             <a href="https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/" class="block no-underline">
-              <img src="/images/vendor-sales-person.png" alt="Am Over Vendors That Are Not Transparent in Pricing" class="h-48 w-full md:w-48 object-cover" />
+              <img src="/images/vendor-sales-person.png" alt="I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing" class="h-48 w-full md:w-48 object-cover" />
             </a>
           </div>
           
@@ -369,11 +386,11 @@
             <time class="text-sm text-gray-500">April 21, 2020</time>
             <h2 class="mt-2 mb-3">
               <a href="https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/" class="text-xl font-semibold text-gray-900 hover:text-blue-600 no-underline">
-                Am Over Vendors That Are Not Transparent in Pricing
+                I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">The days of secret per customer pricing should be over. Vendors should be transparent with pricing and treat all customers the same.</p>
+            <p class="text-gray-600 my-0">I&#39;m done with vendors that hide pricing and reward schmoozing over fairness. Here&#39;s why transparent pricing that treats every customer the same wins my business.</p>
             
             <a href="https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more

--- a/docs/blog/page/3/index.html
+++ b/docs/blog/page/3/index.html
@@ -3,28 +3,41 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Blogs</title>
-  <meta name="description" content="" />
+
+  
+  <title>Blog | Spicer Matthews</title>
+  <meta name="description" content="Essays by Spicer Matthews on AI-first software development, building products, options trading, and entrepreneurship — lessons from 20&#43; years of shipping software." />
+  <meta name="keywords" content="Spicer Matthews blog, AI-first development, software development essays, options trading, building software products, indie hacking" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/" />
+
   <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
 
   
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="Blogs" />
-  <meta property="og:description" content="" />
+  <meta property="og:title" content="Blog | Spicer Matthews" />
+  <meta property="og:description" content="Essays by Spicer Matthews on AI-first software development, building products, options trading, and entrepreneurship — lessons from 20&#43; years of shipping software." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/" />
-  <meta property="og:locale" content="en" />
-
-  
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:alt" content="Blog" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-  
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="" />
+  <meta name="twitter:title" content="Blog | Spicer Matthews" />
+  <meta name="twitter:description" content="Essays by Spicer Matthews on AI-first software development, building products, options trading, and entrepreneurship — lessons from 20&#43; years of shipping software." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","description":"Essays by Spicer Matthews on AI-first software development, building products, options trading, and entrepreneurship — lessons from 20+ years of shipping software.","inLanguage":"en-US","isPartOf":{"@id":"https://spicermatthews.com/#website"},"name":"Blog","url":"https://spicermatthews.com/blog/"}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -116,7 +129,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">Unit Testing is just one area where synchronization is important. Software development should proceed in conjunction with business objectives. Often, software developer ideologies and business goals run in conflict with each other, and I believe they should be in sync.</p>
+            <p class="text-gray-600 my-0">After 20 years writing code, here are my 8 practical rules for when and how to unit test, balancing TDD, coverage, and budget against real business goals.</p>
             
             <a href="https://spicermatthews.com/blog/spicers-rules-on-how-and-when-to-test-your-code/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -145,7 +158,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">I am becoming a big fan of Hugo to build static sites like this one and this one. Since Hugo does not ship with any fancy GUI as other content management systems do -- typically you produce your content within your text editor such as Atom.</p>
+            <p class="text-gray-600 my-0">I&#39;m a big fan of Hugo, but I prefer writing in Google Docs. Here&#39;s my quick workflow for importing Google Docs into Hugo as clean, tidy HTML.</p>
             
             <a href="https://spicermatthews.com/blog/using-hugo-with-google-docs/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -174,7 +187,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">This week, we launched bendmountbachelorvillage.com for really no good reason. For years now, we have been using Airbnb to rent out our vacation rental in Bend, OR.</p>
+            <p class="text-gray-600 my-0">Why my wife and I obsess over delighting customers, from our grandfather&#39;s NAPA store to our software businesses and Airbnb guests in Bend, Oregon.</p>
             
             <a href="https://spicermatthews.com/blog/delighting-customers-with-airbnb/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more
@@ -203,7 +216,7 @@
               </a>
             </h2>
             
-            <p class="text-gray-600 my-0">Today, I am launching, once again, my personal blog. Starting over. Welcome to the new spicermatthews.com</p>
+            <p class="text-gray-600 my-0">I relaunched my personal blog as a static Hugo site styled with Tailwind CSS and hosted on GitHub Pages. Here&#39;s why I ditched the CMS headaches for good.</p>
             
             <a href="https://spicermatthews.com/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more/" class="mt-4 text-blue-600 hover:underline font-medium no-underline inline-flex items-center">
               Read more

--- a/docs/blog/prioritizing-tdd-friendly-languages-and-frameworks/index.html
+++ b/docs/blog/prioritizing-tdd-friendly-languages-and-frameworks/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Prioritizing TDD Friendly Languages and Frameworks</title>
-  <meta name="description" content="" />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Prioritizing TDD Friendly Languages and Frameworks" />
-  <meta property="og:description" content="" />
+  <title>Prioritizing TDD Friendly Languages and Frameworks | Spicer Matthews</title>
+  <meta name="description" content="I pick TDD friendly languages and frameworks like Go and PHP over hard-to-test options like Node.js, and here&#39;s why testing should speed you up, not slow you down." />
+  <meta name="keywords" content="TDD friendly languages and frameworks, best languages for test-driven development, is Go good for TDD, why Node.js is hard to test, choosing a language for unit testing, PHP unit testing vs JavaScript, test-driven development language choice, easiest languages to write unit tests" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/prioritizing-tdd-friendly-languages-and-frameworks/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Prioritizing TDD Friendly Languages and Frameworks | Spicer Matthews" />
+  <meta property="og:description" content="I pick TDD friendly languages and frameworks like Go and PHP over hard-to-test options like Node.js, and here&#39;s why testing should speed you up, not slow you down." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/prioritizing-tdd-friendly-languages-and-frameworks/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/computer-code.jpg" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/computer-code.jpg" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/computer-code.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/computer-code.jpg" />
+  <meta property="og:image:alt" content="Prioritizing TDD Friendly Languages and Frameworks" />
+  <meta property="article:published_time" content="2023-03-18T20:18:58-07:00" />
+  <meta property="article:modified_time" content="2023-03-18T20:18:58-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="TDD friendly languages and frameworks" />
+  <meta property="article:tag" content="best languages for test-driven development" />
+  <meta property="article:tag" content="is Go good for TDD" />
+  <meta property="article:tag" content="why Node.js is hard to test" />
+  <meta property="article:tag" content="choosing a language for unit testing" />
+  <meta property="article:tag" content="PHP unit testing vs JavaScript" />
+  <meta property="article:tag" content="test-driven development language choice" />
+  <meta property="article:tag" content="easiest languages to write unit tests" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/computer-code.jpg" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="" />
+  <meta name="twitter:title" content="Prioritizing TDD Friendly Languages and Frameworks | Spicer Matthews" />
+  <meta name="twitter:description" content="I pick TDD friendly languages and frameworks like Go and PHP over hard-to-test options like Node.js, and here&#39;s why testing should speed you up, not slow you down." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/computer-code.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2023-03-18T20:18:58-07:00","datePublished":"2023-03-18T20:18:58-07:00","description":"I pick TDD friendly languages and frameworks like Go and PHP over hard-to-test options like Node.js, and here's why testing should speed you up, not slow you down.","headline":"Prioritizing TDD Friendly Languages and Frameworks","image":["https://spicermatthews.com/images/computer-code.jpg"],"inLanguage":"en-US","keywords":"TDD friendly languages and frameworks, best languages for test-driven development, is Go good for TDD, why Node.js is hard to test, choosing a language for unit testing, PHP unit testing vs JavaScript, test-driven development language choice, easiest languages to write unit tests","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/prioritizing-tdd-friendly-languages-and-frameworks/","@type":"WebPage"},"name":"Prioritizing TDD Friendly Languages and Frameworks","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/prioritizing-tdd-friendly-languages-and-frameworks/","wordCount":399}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/prioritizing-tdd-friendly-languages-and-frameworks/","name":"Prioritizing TDD Friendly Languages and Frameworks","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -125,8 +150,8 @@
   more enjoyable and not be an extra burden. They should be tools that help developers work faster, rather than additional tasks.
 </p>
 
-<blockquote className="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
-  <p className="mb-2">"Said a different way, unit tests when written to speed up my development process are amazing, but they are super annoying when written as a chore."</p>
+<blockquote class="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
+  <p class="mb-2">"Said a different way, unit tests when written to speed up my development process are amazing, but they are super annoying when written as a chore."</p>
 </blockquote>
 
 <p>
@@ -213,6 +238,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/spicers-rules-on-how-and-when-to-test-your-code/" class="block no-underline group">
+          <img src="/images/talk-code-to-me.png" alt="Spicer&#39;s Rules on How and When To Test Your Code" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Spicer&#39;s Rules on How and When To Test Your Code</span>
+          <time class="block text-sm text-gray-500 mt-1">September 15, 2019</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit/" class="block no-underline group">
+          <img src="/images/computer-code.jpg" alt="Nitpicking Code Quality: A Necessary Evil or a Harmful Habit?" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Nitpicking Code Quality: A Necessary Evil or a Harmful Habit?</span>
+          <time class="block text-sm text-gray-500 mt-1">March 22, 2023</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/full-circle-back-to-the-terminal/" class="block no-underline group">
+          <img src="/images/blog/full-circle-back-to-the-terminal.jpg" alt="Full Circle: Back to the Terminal" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Full Circle: Back to the Terminal</span>
+          <time class="block text-sm text-gray-500 mt-1">February 19, 2026</time>
         </a>
       </div>
     </div>

--- a/docs/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity/index.html
+++ b/docs/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Reimagining Real Estate: A Call for Excellence Over Exclusivity</title>
-  <meta name="description" content="Exploring the need for excellence over barriers in real estate, advocating for innovation and fairness in the industry." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Reimagining Real Estate: A Call for Excellence Over Exclusivity" />
-  <meta property="og:description" content="Exploring the need for excellence over barriers in real estate, advocating for innovation and fairness in the industry." />
+  <title>Reimagining Real Estate: A Call for Excellence Over Exclusivity | Spicer Matthews</title>
+  <meta name="description" content="After 50&#43; real estate deals, I argue the NAR commission settlement should push the industry to compete on excellence, not moats like MLS control." />
+  <meta name="keywords" content="NAR commission settlement, National Association of Realtors lawsuit, real estate agent commissions explained, buying a home without a realtor, real estate industry reform, MLS access restrictions, are realtor commissions worth it, real estate moat" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Reimagining Real Estate: A Call for Excellence Over Exclusivity | Spicer Matthews" />
+  <meta property="og:description" content="After 50&#43; real estate deals, I argue the NAR commission settlement should push the industry to compete on excellence, not moats like MLS control." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/moat.jpeg" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/moat.jpeg" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/moat.jpeg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/moat.jpeg" />
+  <meta property="og:image:alt" content="Reimagining Real Estate: A Call for Excellence Over Exclusivity" />
+  <meta property="article:published_time" content="2024-03-26T12:18:58-07:00" />
+  <meta property="article:modified_time" content="2024-03-26T12:18:58-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="NAR commission settlement" />
+  <meta property="article:tag" content="National Association of Realtors lawsuit" />
+  <meta property="article:tag" content="real estate agent commissions explained" />
+  <meta property="article:tag" content="buying a home without a realtor" />
+  <meta property="article:tag" content="real estate industry reform" />
+  <meta property="article:tag" content="MLS access restrictions" />
+  <meta property="article:tag" content="are realtor commissions worth it" />
+  <meta property="article:tag" content="real estate moat" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/moat.jpeg" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="Exploring the need for excellence over barriers in real estate, advocating for innovation and fairness in the industry." />
+  <meta name="twitter:title" content="Reimagining Real Estate: A Call for Excellence Over Exclusivity | Spicer Matthews" />
+  <meta name="twitter:description" content="After 50&#43; real estate deals, I argue the NAR commission settlement should push the industry to compete on excellence, not moats like MLS control." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/moat.jpeg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2024-03-26T12:18:58-07:00","datePublished":"2024-03-26T12:18:58-07:00","description":"After 50+ real estate deals, I argue the NAR commission settlement should push the industry to compete on excellence, not moats like MLS control.","headline":"Reimagining Real Estate: A Call for Excellence Over Exclusivity","image":["https://spicermatthews.com/images/moat.jpeg"],"inLanguage":"en-US","keywords":"NAR commission settlement, National Association of Realtors lawsuit, real estate agent commissions explained, buying a home without a realtor, real estate industry reform, MLS access restrictions, are realtor commissions worth it, real estate moat","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity/","@type":"WebPage"},"name":"Reimagining Real Estate: A Call for Excellence Over Exclusivity","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity/","wordCount":484}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity/","name":"Reimagining Real Estate: A Call for Excellence Over Exclusivity","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -211,6 +236,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/" class="block no-underline group">
+          <img src="/images/vendor-sales-person.png" alt="I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing</span>
+          <time class="block text-sm text-gray-500 mt-1">April 21, 2020</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too/" class="block no-underline group">
+          <img src="/images/construction-home-project.png" alt="How I Learned to Spot Inflated Bids (and What You Can Do Too)" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">How I Learned to Spot Inflated Bids (and What You Can Do Too)</span>
+          <time class="block text-sm text-gray-500 mt-1">October 15, 2025</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/delighting-customers-with-airbnb/" class="block no-underline group">
+          <img src="/images/condo-rental-in-bend-oregon.png" alt="Delighting Customers With Airbnb" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Delighting Customers With Airbnb</span>
+          <time class="block text-sm text-gray-500 mt-1">July 30, 2019</time>
         </a>
       </div>
     </div>

--- a/docs/blog/remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses/index.html
+++ b/docs/blog/remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Remodeling My Home Proved One Thing: We Need Robots to Build Houses</title>
-  <meta name="description" content="How a 2,000-square-foot remodel showed me just how broken, wasteful, and middleman-heavy the construction industry has become—and why I’m rooting for robots to take over." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Remodeling My Home Proved One Thing: We Need Robots to Build Houses" />
-  <meta property="og:description" content="How a 2,000-square-foot remodel showed me just how broken, wasteful, and middleman-heavy the construction industry has become—and why I’m rooting for robots to take over." />
+  <title>Remodeling My Home Proved One Thing: We Need Robots to Build Houses | Spicer Matthews</title>
+  <meta name="description" content="I got $300K&#43; bids to remodel my home, then did it myself as GC for under $100K. Here&#39;s where construction money really goes, and why I want robots building houses." />
+  <meta name="keywords" content="cost of home remodel vs general contractor bids, why are remodel bids so expensive, acting as your own general contractor, design build firm cost vs DIY GC, where does construction money go middlemen, robots building houses construction automation, 2000 square foot remodel cost, residential construction industry waste" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Remodeling My Home Proved One Thing: We Need Robots to Build Houses | Spicer Matthews" />
+  <meta property="og:description" content="I got $300K&#43; bids to remodel my home, then did it myself as GC for under $100K. Here&#39;s where construction money really goes, and why I want robots building houses." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/robots-building-houses.jpg" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/robots-building-houses.jpg" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/robots-building-houses.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/robots-building-houses.jpg" />
+  <meta property="og:image:alt" content="Remodeling My Home Proved One Thing: We Need Robots to Build Houses" />
+  <meta property="article:published_time" content="2025-12-02T10:00:00-08:00" />
+  <meta property="article:modified_time" content="2025-12-02T10:00:00-08:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="cost of home remodel vs general contractor bids" />
+  <meta property="article:tag" content="why are remodel bids so expensive" />
+  <meta property="article:tag" content="acting as your own general contractor" />
+  <meta property="article:tag" content="design build firm cost vs DIY GC" />
+  <meta property="article:tag" content="where does construction money go middlemen" />
+  <meta property="article:tag" content="robots building houses construction automation" />
+  <meta property="article:tag" content="2000 square foot remodel cost" />
+  <meta property="article:tag" content="residential construction industry waste" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/robots-building-houses.jpg" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="How a 2,000-square-foot remodel showed me just how broken, wasteful, and middleman-heavy the construction industry has become—and why I’m rooting for robots to take over." />
+  <meta name="twitter:title" content="Remodeling My Home Proved One Thing: We Need Robots to Build Houses | Spicer Matthews" />
+  <meta name="twitter:description" content="I got $300K&#43; bids to remodel my home, then did it myself as GC for under $100K. Here&#39;s where construction money really goes, and why I want robots building houses." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/robots-building-houses.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2025-12-02T10:00:00-08:00","datePublished":"2025-12-02T10:00:00-08:00","description":"I got $300K+ bids to remodel my home, then did it myself as GC for under $100K. Here's where construction money really goes, and why I want robots building houses.","headline":"Remodeling My Home Proved One Thing: We Need Robots to Build Houses","image":["https://spicermatthews.com/images/robots-building-houses.jpg"],"inLanguage":"en-US","keywords":"cost of home remodel vs general contractor bids, why are remodel bids so expensive, acting as your own general contractor, design build firm cost vs DIY GC, where does construction money go middlemen, robots building houses construction automation, 2000 square foot remodel cost, residential construction industry waste","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses/","@type":"WebPage"},"name":"Remodeling My Home Proved One Thing: We Need Robots to Build Houses","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses/","wordCount":1685}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses/","name":"Remodeling My Home Proved One Thing: We Need Robots to Build Houses","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -395,6 +420,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/" class="block no-underline group">
+          <img src="/images/vendor-sales-person.png" alt="I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing</span>
+          <time class="block text-sm text-gray-500 mt-1">April 21, 2020</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too/" class="block no-underline group">
+          <img src="/images/construction-home-project.png" alt="How I Learned to Spot Inflated Bids (and What You Can Do Too)" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">How I Learned to Spot Inflated Bids (and What You Can Do Too)</span>
+          <time class="block text-sm text-gray-500 mt-1">October 15, 2025</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity/" class="block no-underline group">
+          <img src="/images/moat.jpeg" alt="Reimagining Real Estate: A Call for Excellence Over Exclusivity" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Reimagining Real Estate: A Call for Excellence Over Exclusivity</span>
+          <time class="block text-sm text-gray-500 mt-1">March 26, 2024</time>
         </a>
       </div>
     </div>

--- a/docs/blog/spicers-rules-on-how-and-when-to-test-your-code/index.html
+++ b/docs/blog/spicers-rules-on-how-and-when-to-test-your-code/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Spicer&#39;s Rules on How and When To Test Your Code</title>
-  <meta name="description" content="Unit Testing is just one area where synchronization is important. Software development should proceed in conjunction with business objectives. Often, software developer ideologies and business goals run in conflict with each other, and I believe they should be in sync." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Spicer&#39;s Rules on How and When To Test Your Code" />
-  <meta property="og:description" content="Unit Testing is just one area where synchronization is important. Software development should proceed in conjunction with business objectives. Often, software developer ideologies and business goals run in conflict with each other, and I believe they should be in sync." />
+  <title>Spicer&#39;s Rules on How and When To Test Your Code | Spicer Matthews</title>
+  <meta name="description" content="After 20 years writing code, here are my 8 practical rules for when and how to unit test, balancing TDD, coverage, and budget against real business goals." />
+  <meta name="keywords" content="when to write unit tests, how and when to test your code, balancing unit testing with business goals, test-driven development pros and cons, is 100% test coverage worth it, unit testing vs integration testing, pragmatic software testing strategy, when to skip writing tests" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/spicers-rules-on-how-and-when-to-test-your-code/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Spicer&#39;s Rules on How and When To Test Your Code | Spicer Matthews" />
+  <meta property="og:description" content="After 20 years writing code, here are my 8 practical rules for when and how to unit test, balancing TDD, coverage, and budget against real business goals." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/spicers-rules-on-how-and-when-to-test-your-code/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/talk-code-to-me.png" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/talk-code-to-me.png" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/talk-code-to-me.png" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/talk-code-to-me.png" />
+  <meta property="og:image:alt" content="Spicer&#39;s Rules on How and When To Test Your Code" />
+  <meta property="article:published_time" content="2019-09-15T12:18:58-07:00" />
+  <meta property="article:modified_time" content="2019-09-15T12:18:58-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="when to write unit tests" />
+  <meta property="article:tag" content="how and when to test your code" />
+  <meta property="article:tag" content="balancing unit testing with business goals" />
+  <meta property="article:tag" content="test-driven development pros and cons" />
+  <meta property="article:tag" content="is 100% test coverage worth it" />
+  <meta property="article:tag" content="unit testing vs integration testing" />
+  <meta property="article:tag" content="pragmatic software testing strategy" />
+  <meta property="article:tag" content="when to skip writing tests" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/talk-code-to-me.png" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="Unit Testing is just one area where synchronization is important. Software development should proceed in conjunction with business objectives. Often, software developer ideologies and business goals run in conflict with each other, and I believe they should be in sync." />
+  <meta name="twitter:title" content="Spicer&#39;s Rules on How and When To Test Your Code | Spicer Matthews" />
+  <meta name="twitter:description" content="After 20 years writing code, here are my 8 practical rules for when and how to unit test, balancing TDD, coverage, and budget against real business goals." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/talk-code-to-me.png" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2019-09-15T12:18:58-07:00","datePublished":"2019-09-15T12:18:58-07:00","description":"After 20 years writing code, here are my 8 practical rules for when and how to unit test, balancing TDD, coverage, and budget against real business goals.","headline":"Spicer's Rules on How and When To Test Your Code","image":["https://spicermatthews.com/images/talk-code-to-me.png"],"inLanguage":"en-US","keywords":"when to write unit tests, how and when to test your code, balancing unit testing with business goals, test-driven development pros and cons, is 100% test coverage worth it, unit testing vs integration testing, pragmatic software testing strategy, when to skip writing tests","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/spicers-rules-on-how-and-when-to-test-your-code/","@type":"WebPage"},"name":"Spicer's Rules on How and When To Test Your Code","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/spicers-rules-on-how-and-when-to-test-your-code/","wordCount":2815}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/spicers-rules-on-how-and-when-to-test-your-code/","name":"Spicer's Rules on How and When To Test Your Code","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -195,8 +220,8 @@
 
 
 
-<blockquote className="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
-	<p className="mb-2">"With test-driven development, a 3 step development processed could be reduced down to 2."</p>
+<blockquote class="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
+	<p class="mb-2">"With test-driven development, a 3 step development processed could be reduced down to 2."</p>
 </blockquote>
 
 
@@ -232,8 +257,8 @@
 	weeks or months later and need to make modifications to that original code. Maybe a bug popped up, or the feature needs to be tweaked. David suggests that every time you open a file you make it better. </p>
 
 
-<blockquote className="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
-	<p className="mb-2">"That every time you open a file you should make it better."</p>
+<blockquote class="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
+	<p class="mb-2">"That every time you open a file you should make it better."</p>
 </blockquote>
 
 
@@ -255,8 +280,8 @@
 	into account. </p>
 
 
-<blockquote className="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
-	<p className="mb-2">"This incremental approach to increase test coverage at the end of the day might cost the same as doing it all at once but think about it in terms of cash flow."</p>
+<blockquote class="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
+	<p class="mb-2">"This incremental approach to increase test coverage at the end of the day might cost the same as doing it all at once but think about it in terms of cash flow."</p>
 </blockquote>
 
 
@@ -391,6 +416,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/prioritizing-tdd-friendly-languages-and-frameworks/" class="block no-underline group">
+          <img src="/images/computer-code.jpg" alt="Prioritizing TDD Friendly Languages and Frameworks" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Prioritizing TDD Friendly Languages and Frameworks</span>
+          <time class="block text-sm text-gray-500 mt-1">March 18, 2023</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit/" class="block no-underline group">
+          <img src="/images/computer-code.jpg" alt="Nitpicking Code Quality: A Necessary Evil or a Harmful Habit?" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Nitpicking Code Quality: A Necessary Evil or a Harmful Habit?</span>
+          <time class="block text-sm text-gray-500 mt-1">March 22, 2023</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/streamlining-code-reviews-maximize-efficiency-and-effectiveness/" class="block no-underline group">
+          <img src="/images/code-review.jpg" alt="Streamlining Code Reviews: Maximize Efficiency and Effectiveness" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Streamlining Code Reviews: Maximize Efficiency and Effectiveness</span>
+          <time class="block text-sm text-gray-500 mt-1">March 30, 2023</time>
         </a>
       </div>
     </div>

--- a/docs/blog/streamlining-code-reviews-maximize-efficiency-and-effectiveness/index.html
+++ b/docs/blog/streamlining-code-reviews-maximize-efficiency-and-effectiveness/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Streamlining Code Reviews: Maximize Efficiency and Effectiveness</title>
-  <meta name="description" content="Rethinking code reviews: balance efficiency &amp; impact, encourage developer discretion, prioritize robust QA workflow, and consider AI-driven solutions." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Streamlining Code Reviews: Maximize Efficiency and Effectiveness" />
-  <meta property="og:description" content="Rethinking code reviews: balance efficiency &amp; impact, encourage developer discretion, prioritize robust QA workflow, and consider AI-driven solutions." />
+  <title>Streamlining Code Reviews: Maximize Efficiency and Effectiveness | Spicer Matthews</title>
+  <meta name="description" content="After years on different teams, here is my contrarian take on code reviews: make pull requests developer discretion, lean on QA, and let AI help." />
+  <meta name="keywords" content="streamlining code reviews, code review best practices, are pull requests worth it, code review at developer discretion, QA workflow vs code reviews, AI code review, reducing pull request overhead, code review process for small teams" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/streamlining-code-reviews-maximize-efficiency-and-effectiveness/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Streamlining Code Reviews: Maximize Efficiency and Effectiveness | Spicer Matthews" />
+  <meta property="og:description" content="After years on different teams, here is my contrarian take on code reviews: make pull requests developer discretion, lean on QA, and let AI help." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/streamlining-code-reviews-maximize-efficiency-and-effectiveness/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/code-review.jpg" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/code-review.jpg" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/code-review.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/code-review.jpg" />
+  <meta property="og:image:alt" content="Streamlining Code Reviews: Maximize Efficiency and Effectiveness" />
+  <meta property="article:published_time" content="2023-03-30T20:18:58-07:00" />
+  <meta property="article:modified_time" content="2023-03-30T20:18:58-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="streamlining code reviews" />
+  <meta property="article:tag" content="code review best practices" />
+  <meta property="article:tag" content="are pull requests worth it" />
+  <meta property="article:tag" content="code review at developer discretion" />
+  <meta property="article:tag" content="QA workflow vs code reviews" />
+  <meta property="article:tag" content="AI code review" />
+  <meta property="article:tag" content="reducing pull request overhead" />
+  <meta property="article:tag" content="code review process for small teams" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/code-review.jpg" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="Rethinking code reviews: balance efficiency &amp; impact, encourage developer discretion, prioritize robust QA workflow, and consider AI-driven solutions." />
+  <meta name="twitter:title" content="Streamlining Code Reviews: Maximize Efficiency and Effectiveness | Spicer Matthews" />
+  <meta name="twitter:description" content="After years on different teams, here is my contrarian take on code reviews: make pull requests developer discretion, lean on QA, and let AI help." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/code-review.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2023-03-30T20:18:58-07:00","datePublished":"2023-03-30T20:18:58-07:00","description":"After years on different teams, here is my contrarian take on code reviews: make pull requests developer discretion, lean on QA, and let AI help.","headline":"Streamlining Code Reviews: Maximize Efficiency and Effectiveness","image":["https://spicermatthews.com/images/code-review.jpg"],"inLanguage":"en-US","keywords":"streamlining code reviews, code review best practices, are pull requests worth it, code review at developer discretion, QA workflow vs code reviews, AI code review, reducing pull request overhead, code review process for small teams","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/streamlining-code-reviews-maximize-efficiency-and-effectiveness/","@type":"WebPage"},"name":"Streamlining Code Reviews: Maximize Efficiency and Effectiveness","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/streamlining-code-reviews-maximize-efficiency-and-effectiveness/","wordCount":523}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/streamlining-code-reviews-maximize-efficiency-and-effectiveness/","name":"Streamlining Code Reviews: Maximize Efficiency and Effectiveness","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -226,6 +251,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit/" class="block no-underline group">
+          <img src="/images/computer-code.jpg" alt="Nitpicking Code Quality: A Necessary Evil or a Harmful Habit?" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Nitpicking Code Quality: A Necessary Evil or a Harmful Habit?</span>
+          <time class="block text-sm text-gray-500 mt-1">March 22, 2023</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/spicers-rules-on-how-and-when-to-test-your-code/" class="block no-underline group">
+          <img src="/images/talk-code-to-me.png" alt="Spicer&#39;s Rules on How and When To Test Your Code" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Spicer&#39;s Rules on How and When To Test Your Code</span>
+          <time class="block text-sm text-gray-500 mt-1">September 15, 2019</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/my-new-ai-first-development-workflow-github-issues/" class="block no-underline group">
+          <img src="/images/github-issues.png" alt="My New AI-First Development Workflow - Github Issues" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">My New AI-First Development Workflow - Github Issues</span>
+          <time class="block text-sm text-gray-500 mt-1">December 29, 2025</time>
         </a>
       </div>
     </div>

--- a/docs/blog/the-ai-side-hustle-revolution-turning-niche-ideas-into-income/index.html
+++ b/docs/blog/the-ai-side-hustle-revolution-turning-niche-ideas-into-income/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>The AI Side Hustle Revolution: Turning Niche Ideas into Income</title>
-  <meta name="description" content="How AI tools like Claude and GitHub Copilot enabled me to build OregonPastDueRent.com in under 80 hours and $1000, proving that niche software ideas are now profitable side hustles for developers." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="The AI Side Hustle Revolution: Turning Niche Ideas into Income" />
-  <meta property="og:description" content="How AI tools like Claude and GitHub Copilot enabled me to build OregonPastDueRent.com in under 80 hours and $1000, proving that niche software ideas are now profitable side hustles for developers." />
+  <title>The AI Side Hustle Revolution: Turning Niche Ideas into Income | Spicer Matthews</title>
+  <meta name="description" content="I built OregonPastDueRent.com in under 80 hours and $1000 using Claude and GitHub Copilot. Here&#39;s why AI makes niche software a real side hustle for developers." />
+  <meta name="keywords" content="AI side hustle for developers, building niche software with AI, vibe coding a product, build a SaaS with Claude and GitHub Copilot, niche micro-SaaS business ideas, make money as a software developer with AI, launch a side project in 80 hours, AI coding tools to build a startup" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/the-ai-side-hustle-revolution-turning-niche-ideas-into-income/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="The AI Side Hustle Revolution: Turning Niche Ideas into Income | Spicer Matthews" />
+  <meta property="og:description" content="I built OregonPastDueRent.com in under 80 hours and $1000 using Claude and GitHub Copilot. Here&#39;s why AI makes niche software a real side hustle for developers." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/the-ai-side-hustle-revolution-turning-niche-ideas-into-income/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/ai-side-hustle-coding.jpg" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/ai-side-hustle-coding.jpg" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/ai-side-hustle-coding.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/ai-side-hustle-coding.jpg" />
+  <meta property="og:image:alt" content="The AI Side Hustle Revolution: Turning Niche Ideas into Income" />
+  <meta property="article:published_time" content="2025-06-06T10:00:00-07:00" />
+  <meta property="article:modified_time" content="2025-06-06T10:00:00-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="AI side hustle for developers" />
+  <meta property="article:tag" content="building niche software with AI" />
+  <meta property="article:tag" content="vibe coding a product" />
+  <meta property="article:tag" content="build a SaaS with Claude and GitHub Copilot" />
+  <meta property="article:tag" content="niche micro-SaaS business ideas" />
+  <meta property="article:tag" content="make money as a software developer with AI" />
+  <meta property="article:tag" content="launch a side project in 80 hours" />
+  <meta property="article:tag" content="AI coding tools to build a startup" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/ai-side-hustle-coding.jpg" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="How AI tools like Claude and GitHub Copilot enabled me to build OregonPastDueRent.com in under 80 hours and $1000, proving that niche software ideas are now profitable side hustles for developers." />
+  <meta name="twitter:title" content="The AI Side Hustle Revolution: Turning Niche Ideas into Income | Spicer Matthews" />
+  <meta name="twitter:description" content="I built OregonPastDueRent.com in under 80 hours and $1000 using Claude and GitHub Copilot. Here&#39;s why AI makes niche software a real side hustle for developers." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/ai-side-hustle-coding.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2025-06-06T10:00:00-07:00","datePublished":"2025-06-06T10:00:00-07:00","description":"I built OregonPastDueRent.com in under 80 hours and $1000 using Claude and GitHub Copilot. Here's why AI makes niche software a real side hustle for developers.","headline":"The AI Side Hustle Revolution: Turning Niche Ideas into Income","image":["https://spicermatthews.com/images/ai-side-hustle-coding.jpg"],"inLanguage":"en-US","keywords":"AI side hustle for developers, building niche software with AI, vibe coding a product, build a SaaS with Claude and GitHub Copilot, niche micro-SaaS business ideas, make money as a software developer with AI, launch a side project in 80 hours, AI coding tools to build a startup","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/the-ai-side-hustle-revolution-turning-niche-ideas-into-income/","@type":"WebPage"},"name":"The AI Side Hustle Revolution: Turning Niche Ideas into Income","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/the-ai-side-hustle-revolution-turning-niche-ideas-into-income/","wordCount":588}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/the-ai-side-hustle-revolution-turning-niche-ideas-into-income/","name":"The AI Side Hustle Revolution: Turning Niche Ideas into Income","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -243,6 +268,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/just-do-stuff/" class="block no-underline group">
+          <img src="/images/blog/just-do-stuff.jpg" alt="Just Do Stuff" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Just Do Stuff</span>
+          <time class="block text-sm text-gray-500 mt-1">February 3, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/" class="block no-underline group">
+          <img src="/images/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one.png" alt="I Vibe Coded a Screenshot Tool Because Claude Code Needed One" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Vibe Coded a Screenshot Tool Because Claude Code Needed One</span>
+          <time class="block text-sm text-gray-500 mt-1">February 24, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/why-100-customers-at-200-beats-1000-at-20/" class="block no-underline group">
+          <img src="/images/200-month.jpg" alt="Why 100 Customers at $200 Beats 1,000 at $20" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Why 100 Customers at $200 Beats 1,000 at $20</span>
+          <time class="block text-sm text-gray-500 mt-1">January 19, 2026</time>
         </a>
       </div>
     </div>

--- a/docs/blog/the-stock-market-is-a-drunken-idiot-you-should-profit-from-it/index.html
+++ b/docs/blog/the-stock-market-is-a-drunken-idiot-you-should-profit-from-it/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>The Stock Market Is a Drunken Idiot -- You Should Profit From It</title>
-  <meta name="description" content="" />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="The Stock Market Is a Drunken Idiot -- You Should Profit From It" />
-  <meta property="og:description" content="" />
+  <title>The Stock Market Is a Drunken Idiot -- You Should Profit From It | Spicer Matthews</title>
+  <meta name="description" content="I treat erratic stocks like drunk people: loud, volatile, and surprisingly predictable. Here&#39;s how I spot volatile stocks and swing trade the chaos for profit." />
+  <meta name="keywords" content="how to spot volatile stocks for swing trading, identify volatile stocks to trade, trading high volatility meme stocks, swing trading volatile stocks strategy, using volume to find volatile stocks, how to profit from stock market volatility, GameStop AMC meme stock volatility, signs a stock is about to make a big move" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/the-stock-market-is-a-drunken-idiot-you-should-profit-from-it/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="The Stock Market Is a Drunken Idiot -- You Should Profit From It | Spicer Matthews" />
+  <meta property="og:description" content="I treat erratic stocks like drunk people: loud, volatile, and surprisingly predictable. Here&#39;s how I spot volatile stocks and swing trade the chaos for profit." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/the-stock-market-is-a-drunken-idiot-you-should-profit-from-it/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/drunk-people-dancing.jpg" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/drunk-people-dancing.jpg" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/drunk-people-dancing.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/drunk-people-dancing.jpg" />
+  <meta property="og:image:alt" content="The Stock Market Is a Drunken Idiot -- You Should Profit From It" />
+  <meta property="article:published_time" content="2023-02-24T20:18:58-07:00" />
+  <meta property="article:modified_time" content="2023-02-24T20:18:58-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="how to spot volatile stocks for swing trading" />
+  <meta property="article:tag" content="identify volatile stocks to trade" />
+  <meta property="article:tag" content="trading high volatility meme stocks" />
+  <meta property="article:tag" content="swing trading volatile stocks strategy" />
+  <meta property="article:tag" content="using volume to find volatile stocks" />
+  <meta property="article:tag" content="how to profit from stock market volatility" />
+  <meta property="article:tag" content="GameStop AMC meme stock volatility" />
+  <meta property="article:tag" content="signs a stock is about to make a big move" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/drunk-people-dancing.jpg" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="" />
+  <meta name="twitter:title" content="The Stock Market Is a Drunken Idiot -- You Should Profit From It | Spicer Matthews" />
+  <meta name="twitter:description" content="I treat erratic stocks like drunk people: loud, volatile, and surprisingly predictable. Here&#39;s how I spot volatile stocks and swing trade the chaos for profit." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/drunk-people-dancing.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2023-02-24T20:18:58-07:00","datePublished":"2023-02-24T20:18:58-07:00","description":"I treat erratic stocks like drunk people: loud, volatile, and surprisingly predictable. Here's how I spot volatile stocks and swing trade the chaos for profit.","headline":"The Stock Market Is a Drunken Idiot -- You Should Profit From It","image":["https://spicermatthews.com/images/drunk-people-dancing.jpg"],"inLanguage":"en-US","keywords":"how to spot volatile stocks for swing trading, identify volatile stocks to trade, trading high volatility meme stocks, swing trading volatile stocks strategy, using volume to find volatile stocks, how to profit from stock market volatility, GameStop AMC meme stock volatility, signs a stock is about to make a big move","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/the-stock-market-is-a-drunken-idiot-you-should-profit-from-it/","@type":"WebPage"},"name":"The Stock Market Is a Drunken Idiot -- You Should Profit From It","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/the-stock-market-is-a-drunken-idiot-you-should-profit-from-it/","wordCount":631}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/the-stock-market-is-a-drunken-idiot-you-should-profit-from-it/","name":"The Stock Market Is a Drunken Idiot -- You Should Profit From It","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -164,8 +189,8 @@
   before they crash, recover from a hangover, and get back to normal. These are trading opportunities.
 </p>
 
-<blockquote className="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
-  <p className="mb-2">
+<blockquote class="p-4 bg-neutral-100 text-neutral-600 border-l-4 border-neutral-500 italic quote">
+  <p class="mb-2">
     I should note that day traders can also make the same comparison, but I'm talking more about swing trading. You might profit over the course of a few days, weeks, or months by
     identifying a drunken stock. These stocks are very predictable, just like a drunken person.
   </p>
@@ -242,6 +267,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too/" class="block no-underline group">
+          <img src="/images/construction-home-project.png" alt="How I Learned to Spot Inflated Bids (and What You Can Do Too)" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">How I Learned to Spot Inflated Bids (and What You Can Do Too)</span>
+          <time class="block text-sm text-gray-500 mt-1">October 15, 2025</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/" class="block no-underline group">
+          <img src="/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png" alt="I Built a Tradier CLI Because AI Agents Deserve Better Tools" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Built a Tradier CLI Because AI Agents Deserve Better Tools</span>
+          <time class="block text-sm text-gray-500 mt-1">March 18, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/why-i-built-a-cli-for-massive-financial-data/" class="block no-underline group">
+          <img src="/images/blog/massive-cli.jpg" alt="Why I Built a CLI for Massive Financial Data" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Why I Built a CLI for Massive Financial Data</span>
+          <time class="block text-sm text-gray-500 mt-1">February 16, 2026</time>
         </a>
       </div>
     </div>

--- a/docs/blog/using-hugo-with-google-docs/index.html
+++ b/docs/blog/using-hugo-with-google-docs/index.html
@@ -3,28 +3,52 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Using Hugo with Google Docs</title>
-  <meta name="description" content="I am becoming a big fan of Hugo to build static sites like this one and this one. Since Hugo does not ship with any fancy GUI as other content management systems do -- typically you produce your content within your text editor such as Atom." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Using Hugo with Google Docs" />
-  <meta property="og:description" content="I am becoming a big fan of Hugo to build static sites like this one and this one. Since Hugo does not ship with any fancy GUI as other content management systems do -- typically you produce your content within your text editor such as Atom." />
+  <title>Using Hugo with Google Docs | Spicer Matthews</title>
+  <meta name="description" content="I&#39;m a big fan of Hugo, but I prefer writing in Google Docs. Here&#39;s my quick workflow for importing Google Docs into Hugo as clean, tidy HTML." />
+  <meta name="keywords" content="using Hugo with Google Docs, import Google Docs into Hugo, write Hugo posts in Google Docs, clean up Google Docs HTML export, Hugo content workflow, convert Google Docs to clean HTML, Hugo static site blogging tips" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/using-hugo-with-google-docs/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Using Hugo with Google Docs | Spicer Matthews" />
+  <meta property="og:description" content="I&#39;m a big fan of Hugo, but I prefer writing in Google Docs. Here&#39;s my quick workflow for importing Google Docs into Hugo as clean, tidy HTML." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/using-hugo-with-google-docs/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/editing-hugo-post-in-atom.png" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/editing-hugo-post-in-atom.png" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/editing-hugo-post-in-atom.png" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/editing-hugo-post-in-atom.png" />
+  <meta property="og:image:alt" content="Using Hugo with Google Docs" />
+  <meta property="article:published_time" content="2019-08-01T12:18:58-07:00" />
+  <meta property="article:modified_time" content="2019-08-01T12:18:58-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="using Hugo with Google Docs" />
+  <meta property="article:tag" content="import Google Docs into Hugo" />
+  <meta property="article:tag" content="write Hugo posts in Google Docs" />
+  <meta property="article:tag" content="clean up Google Docs HTML export" />
+  <meta property="article:tag" content="Hugo content workflow" />
+  <meta property="article:tag" content="convert Google Docs to clean HTML" />
+  <meta property="article:tag" content="Hugo static site blogging tips" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/editing-hugo-post-in-atom.png" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="I am becoming a big fan of Hugo to build static sites like this one and this one. Since Hugo does not ship with any fancy GUI as other content management systems do -- typically you produce your content within your text editor such as Atom." />
+  <meta name="twitter:title" content="Using Hugo with Google Docs | Spicer Matthews" />
+  <meta name="twitter:description" content="I&#39;m a big fan of Hugo, but I prefer writing in Google Docs. Here&#39;s my quick workflow for importing Google Docs into Hugo as clean, tidy HTML." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/editing-hugo-post-in-atom.png" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2019-08-01T12:18:58-07:00","datePublished":"2019-08-01T12:18:58-07:00","description":"I'm a big fan of Hugo, but I prefer writing in Google Docs. Here's my quick workflow for importing Google Docs into Hugo as clean, tidy HTML.","headline":"Using Hugo with Google Docs","image":["https://spicermatthews.com/images/editing-hugo-post-in-atom.png"],"inLanguage":"en-US","keywords":"using Hugo with Google Docs, import Google Docs into Hugo, write Hugo posts in Google Docs, clean up Google Docs HTML export, Hugo content workflow, convert Google Docs to clean HTML, Hugo static site blogging tips","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/using-hugo-with-google-docs/","@type":"WebPage"},"name":"Using Hugo with Google Docs","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/using-hugo-with-google-docs/","wordCount":191}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/using-hugo-with-google-docs/","name":"Using Hugo with Google Docs","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -203,6 +227,23 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more/" class="block no-underline group">
+          <img src="/images/spicer-matthews-wine-drinking.jpg" alt="Hello World: My New Blog, Hugo, Tailwind CSS, and More" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Hello World: My New Blog, Hugo, Tailwind CSS, and More</span>
+          <time class="block text-sm text-gray-500 mt-1">July 17, 2019</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/full-circle-back-to-the-terminal/" class="block no-underline group">
+          <img src="/images/blog/full-circle-back-to-the-terminal.jpg" alt="Full Circle: Back to the Terminal" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Full Circle: Back to the Terminal</span>
+          <time class="block text-sm text-gray-500 mt-1">February 19, 2026</time>
         </a>
       </div>
     </div>

--- a/docs/blog/why-100-customers-at-200-beats-1000-at-20/index.html
+++ b/docs/blog/why-100-customers-at-200-beats-1000-at-20/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Why 100 Customers at $200 Beats 1,000 at $20</title>
-  <meta name="description" content="Getting 1,000 customers is brutal. But 100 customers at $200/month? That&#39;s $240k/year—and easier than you think. Here&#39;s why fewer customers means more profit." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Why 100 Customers at $200 Beats 1,000 at $20" />
-  <meta property="og:description" content="Getting 1,000 customers is brutal. But 100 customers at $200/month? That&#39;s $240k/year—and easier than you think. Here&#39;s why fewer customers means more profit." />
+  <title>Why 100 Customers at $200 Beats 1,000 at $20 | Spicer Matthews</title>
+  <meta name="description" content="I&#39;ve started multiple SaaS products, and getting 1,000 customers crushes most founders. Here&#39;s why 100 customers at $200/month is the smarter path to $100k profit." />
+  <meta name="keywords" content="100 customers at $200 a month SaaS, premium pricing for solo SaaS founders, how many customers do you need to make $100k, indie SaaS pricing strategy, small SaaS business model, charge more fewer customers, niche SaaS premium pricing, work backwards from income goal business" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/why-100-customers-at-200-beats-1000-at-20/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Why 100 Customers at $200 Beats 1,000 at $20 | Spicer Matthews" />
+  <meta property="og:description" content="I&#39;ve started multiple SaaS products, and getting 1,000 customers crushes most founders. Here&#39;s why 100 customers at $200/month is the smarter path to $100k profit." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/why-100-customers-at-200-beats-1000-at-20/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/200-month.jpg" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/200-month.jpg" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/200-month.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/200-month.jpg" />
+  <meta property="og:image:alt" content="Why 100 Customers at $200 Beats 1,000 at $20" />
+  <meta property="article:published_time" content="2026-01-19T10:00:00-07:00" />
+  <meta property="article:modified_time" content="2026-01-19T10:00:00-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="100 customers at $200 a month SaaS" />
+  <meta property="article:tag" content="premium pricing for solo SaaS founders" />
+  <meta property="article:tag" content="how many customers do you need to make $100k" />
+  <meta property="article:tag" content="indie SaaS pricing strategy" />
+  <meta property="article:tag" content="small SaaS business model" />
+  <meta property="article:tag" content="charge more fewer customers" />
+  <meta property="article:tag" content="niche SaaS premium pricing" />
+  <meta property="article:tag" content="work backwards from income goal business" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/200-month.jpg" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="Getting 1,000 customers is brutal. But 100 customers at $200/month? That&#39;s $240k/year—and easier than you think. Here&#39;s why fewer customers means more profit." />
+  <meta name="twitter:title" content="Why 100 Customers at $200 Beats 1,000 at $20 | Spicer Matthews" />
+  <meta name="twitter:description" content="I&#39;ve started multiple SaaS products, and getting 1,000 customers crushes most founders. Here&#39;s why 100 customers at $200/month is the smarter path to $100k profit." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/200-month.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2026-01-19T10:00:00-07:00","datePublished":"2026-01-19T10:00:00-07:00","description":"I've started multiple SaaS products, and getting 1,000 customers crushes most founders. Here's why 100 customers at $200/month is the smarter path to $100k profit.","headline":"Why 100 Customers at $200 Beats 1,000 at $20","image":["https://spicermatthews.com/images/200-month.jpg"],"inLanguage":"en-US","keywords":"100 customers at $200 a month SaaS, premium pricing for solo SaaS founders, how many customers do you need to make $100k, indie SaaS pricing strategy, small SaaS business model, charge more fewer customers, niche SaaS premium pricing, work backwards from income goal business","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/why-100-customers-at-200-beats-1000-at-20/","@type":"WebPage"},"name":"Why 100 Customers at $200 Beats 1,000 at $20","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/why-100-customers-at-200-beats-1000-at-20/","wordCount":1203}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/why-100-customers-at-200-beats-1000-at-20/","name":"Why 100 Customers at $200 Beats 1,000 at $20","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -435,6 +460,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/just-do-stuff/" class="block no-underline group">
+          <img src="/images/blog/just-do-stuff.jpg" alt="Just Do Stuff" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Just Do Stuff</span>
+          <time class="block text-sm text-gray-500 mt-1">February 3, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/you-dont-lack-time-you-lack-a-system/" class="block no-underline group">
+          <img src="/images/system.png" alt="You Don&#39;t Lack Time. You Lack a System." class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">You Don&#39;t Lack Time. You Lack a System.</span>
+          <time class="block text-sm text-gray-500 mt-1">January 13, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/" class="block no-underline group">
+          <img src="/images/vendor-sales-person.png" alt="I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing</span>
+          <time class="block text-sm text-gray-500 mt-1">April 21, 2020</time>
         </a>
       </div>
     </div>

--- a/docs/blog/why-i-built-a-cli-for-massive-financial-data/index.html
+++ b/docs/blog/why-i-built-a-cli-for-massive-financial-data/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Why I Built a CLI for Massive Financial Data</title>
-  <meta name="description" content="MCP servers flood your AI agent&#39;s context window. A CLI doesn&#39;t. I built Massive CLI — a command-line tool for the Massive financial data API — because a single binary that outputs clean tables or JSON is a better fit for both humans and AI agents." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Why I Built a CLI for Massive Financial Data" />
-  <meta property="og:description" content="MCP servers flood your AI agent&#39;s context window. A CLI doesn&#39;t. I built Massive CLI — a command-line tool for the Massive financial data API — because a single binary that outputs clean tables or JSON is a better fit for both humans and AI agents." />
+  <title>Why I Built a CLI for Massive Financial Data | Spicer Matthews</title>
+  <meta name="description" content="MCP servers flood your AI agent&#39;s context window. So I built Massive CLI, a command-line tool for the Massive financial data API that outputs clean tables or JSON." />
+  <meta name="keywords" content="CLI for financial market data, Massive API CLI, CLI vs MCP server for AI agents, financial data CLI for Claude Code, stock and options market data command line tool, AI agent tools without context window bloat, Go CLI for market data API, real-time market data terminal tool" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/why-i-built-a-cli-for-massive-financial-data/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Why I Built a CLI for Massive Financial Data | Spicer Matthews" />
+  <meta property="og:description" content="MCP servers flood your AI agent&#39;s context window. So I built Massive CLI, a command-line tool for the Massive financial data API that outputs clean tables or JSON." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/why-i-built-a-cli-for-massive-financial-data/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/blog/massive-cli.jpg" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/massive-cli.jpg" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/blog/massive-cli.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/blog/massive-cli.jpg" />
+  <meta property="og:image:alt" content="Why I Built a CLI for Massive Financial Data" />
+  <meta property="article:published_time" content="2026-02-16T10:00:00-07:00" />
+  <meta property="article:modified_time" content="2026-02-16T10:00:00-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="CLI for financial market data" />
+  <meta property="article:tag" content="Massive API CLI" />
+  <meta property="article:tag" content="CLI vs MCP server for AI agents" />
+  <meta property="article:tag" content="financial data CLI for Claude Code" />
+  <meta property="article:tag" content="stock and options market data command line tool" />
+  <meta property="article:tag" content="AI agent tools without context window bloat" />
+  <meta property="article:tag" content="Go CLI for market data API" />
+  <meta property="article:tag" content="real-time market data terminal tool" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/blog/massive-cli.jpg" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="MCP servers flood your AI agent&#39;s context window. A CLI doesn&#39;t. I built Massive CLI — a command-line tool for the Massive financial data API — because a single binary that outputs clean tables or JSON is a better fit for both humans and AI agents." />
+  <meta name="twitter:title" content="Why I Built a CLI for Massive Financial Data | Spicer Matthews" />
+  <meta name="twitter:description" content="MCP servers flood your AI agent&#39;s context window. So I built Massive CLI, a command-line tool for the Massive financial data API that outputs clean tables or JSON." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/blog/massive-cli.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2026-02-16T10:00:00-07:00","datePublished":"2026-02-16T10:00:00-07:00","description":"MCP servers flood your AI agent's context window. So I built Massive CLI, a command-line tool for the Massive financial data API that outputs clean tables or JSON.","headline":"Why I Built a CLI for Massive Financial Data","image":["https://spicermatthews.com/images/blog/massive-cli.jpg"],"inLanguage":"en-US","keywords":"CLI for financial market data, Massive API CLI, CLI vs MCP server for AI agents, financial data CLI for Claude Code, stock and options market data command line tool, AI agent tools without context window bloat, Go CLI for market data API, real-time market data terminal tool","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/why-i-built-a-cli-for-massive-financial-data/","@type":"WebPage"},"name":"Why I Built a CLI for Massive Financial Data","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/why-i-built-a-cli-for-massive-financial-data/","wordCount":1421}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/why-i-built-a-cli-for-massive-financial-data/","name":"Why I Built a CLI for Massive Financial Data","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -443,6 +468,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/" class="block no-underline group">
+          <img src="/images/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools.png" alt="I Built a Tradier CLI Because AI Agents Deserve Better Tools" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Built a Tradier CLI Because AI Agents Deserve Better Tools</span>
+          <time class="block text-sm text-gray-500 mt-1">March 18, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/my-new-ai-first-development-workflow-github-issues/" class="block no-underline group">
+          <img src="/images/github-issues.png" alt="My New AI-First Development Workflow - Github Issues" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">My New AI-First Development Workflow - Github Issues</span>
+          <time class="block text-sm text-gray-500 mt-1">December 29, 2025</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/i-built-a-personal-ai-assistant-that-lives-in-slack/" class="block no-underline group">
+          <img src="/images/autumn-ai-assistant.png" alt="I Built a Personal AI Assistant That Lives in Slack" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Built a Personal AI Assistant That Lives in Slack</span>
+          <time class="block text-sm text-gray-500 mt-1">January 30, 2026</time>
         </a>
       </div>
     </div>

--- a/docs/blog/you-dont-lack-time-you-lack-a-system/index.html
+++ b/docs/blog/you-dont-lack-time-you-lack-a-system/index.html
@@ -3,28 +3,53 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>You Don&#39;t Lack Time. You Lack a System.</title>
-  <meta name="description" content="Most of us don&#39;t need more hours in the day—we need systems that protect our attention and reduce friction. Here&#39;s how small changes compound into a life spent on what actually matters." />
-  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
 
   
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="You Don&#39;t Lack Time. You Lack a System." />
-  <meta property="og:description" content="Most of us don&#39;t need more hours in the day—we need systems that protect our attention and reduce friction. Here&#39;s how small changes compound into a life spent on what actually matters." />
+  <title>You Don&#39;t Lack Time. You Lack a System. | Spicer Matthews</title>
+  <meta name="description" content="I don&#39;t need more hours in the day, and neither do you. Here&#39;s how I build systems that protect my attention, reduce friction, and compound into real time." />
+  <meta name="keywords" content="building systems to manage your time, you don&#39;t lack time you lack a system, systems to protect your attention, automate outsource eliminate repetitive tasks, deep work and reducing friction, time management systems for entrepreneurs, batching email and text messages, compound effect of small time savings" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/blog/you-dont-lack-time-you-lack-a-system/" />
+
+  <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
+
+  
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="You Don&#39;t Lack Time. You Lack a System. | Spicer Matthews" />
+  <meta property="og:description" content="I don&#39;t need more hours in the day, and neither do you. Here&#39;s how I build systems that protect my attention, reduce friction, and compound into real time." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/blog/you-dont-lack-time-you-lack-a-system/" />
-  <meta property="og:locale" content="en" />
-
-   <meta property="og:image" content="https://spicermatthews.com/images/system.png" /> <meta property="og:image:secure_url" content="https://spicermatthews.com/images/system.png" /> 
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/system.png" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/system.png" />
+  <meta property="og:image:alt" content="You Don&#39;t Lack Time. You Lack a System." />
+  <meta property="article:published_time" content="2026-01-13T10:00:00-07:00" />
+  <meta property="article:modified_time" content="2026-01-13T10:00:00-07:00" />
+  <meta property="article:author" content="Spicer Matthews" />
+  <meta property="article:section" content="Blog" />
+  <meta property="article:tag" content="building systems to manage your time" />
+  <meta property="article:tag" content="you don&#39;t lack time you lack a system" />
+  <meta property="article:tag" content="systems to protect your attention" />
+  <meta property="article:tag" content="automate outsource eliminate repetitive tasks" />
+  <meta property="article:tag" content="deep work and reducing friction" />
+  <meta property="article:tag" content="time management systems for entrepreneurs" />
+  <meta property="article:tag" content="batching email and text messages" />
+  <meta property="article:tag" content="compound effect of small time savings" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:image:src" content="https://spicermatthews.com/images/system.png" /> 
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="Most of us don&#39;t need more hours in the day—we need systems that protect our attention and reduce friction. Here&#39;s how small changes compound into a life spent on what actually matters." />
+  <meta name="twitter:title" content="You Don&#39;t Lack Time. You Lack a System. | Spicer Matthews" />
+  <meta name="twitter:description" content="I don&#39;t need more hours in the day, and neither do you. Here&#39;s how I build systems that protect my attention, reduce friction, and compound into real time." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/system.png" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","articleSection":"Blog","author":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"dateModified":"2026-01-13T10:00:00-07:00","datePublished":"2026-01-13T10:00:00-07:00","description":"I don't need more hours in the day, and neither do you. Here's how I build systems that protect my attention, reduce friction, and compound into real time.","headline":"You Don't Lack Time. You Lack a System.","image":["https://spicermatthews.com/images/system.png"],"inLanguage":"en-US","keywords":"building systems to manage your time, you don't lack time you lack a system, systems to protect your attention, automate outsource eliminate repetitive tasks, deep work and reducing friction, time management systems for entrepreneurs, batching email and text messages, compound effect of small time savings","mainEntityOfPage":{"@id":"https://spicermatthews.com/blog/you-dont-lack-time-you-lack-a-system/","@type":"WebPage"},"name":"You Don't Lack Time. You Lack a System.","publisher":{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},"url":"https://spicermatthews.com/blog/you-dont-lack-time-you-lack-a-system/","wordCount":647}</script><script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","item":"https://spicermatthews.com/","name":"Home","position":1},{"@type":"ListItem","item":"https://spicermatthews.com/blog/","name":"Blog","position":2},{"@type":"ListItem","item":"https://spicermatthews.com/blog/you-dont-lack-time-you-lack-a-system/","name":"You Don't Lack Time. You Lack a System.","position":3}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -341,6 +366,28 @@
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
           Tweet
+        </a>
+      </div>
+    </div>
+
+    
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        <a href="https://spicermatthews.com/blog/just-do-stuff/" class="block no-underline group">
+          <img src="/images/blog/just-do-stuff.jpg" alt="Just Do Stuff" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">Just Do Stuff</span>
+          <time class="block text-sm text-gray-500 mt-1">February 3, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/i-built-a-personal-ai-assistant-that-lives-in-slack/" class="block no-underline group">
+          <img src="/images/autumn-ai-assistant.png" alt="I Built a Personal AI Assistant That Lives in Slack" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">I Built a Personal AI Assistant That Lives in Slack</span>
+          <time class="block text-sm text-gray-500 mt-1">January 30, 2026</time>
+        </a>
+        <a href="https://spicermatthews.com/blog/my-new-ai-first-development-workflow-github-issues/" class="block no-underline group">
+          <img src="/images/github-issues.png" alt="My New AI-First Development Workflow - Github Issues" class="w-full h-32 object-cover rounded-lg mb-3" />
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">My New AI-First Development Workflow - Github Issues</span>
+          <time class="block text-sm text-gray-500 mt-1">December 29, 2025</time>
         </a>
       </div>
     </div>

--- a/docs/css/build.css
+++ b/docs/css/build.css
@@ -960,11 +960,6 @@ nav a {
   margin-bottom: 1rem;
 }
 
-.my-5 {
-  margin-top: 1.25rem;
-  margin-bottom: 1.25rem;
-}
-
 .my-6 {
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
@@ -1005,14 +1000,6 @@ nav a {
 
 .ml-4 {
   margin-left: 1rem;
-}
-
-.ml-5 {
-  margin-left: 1.25rem;
-}
-
-.mr-0 {
-  margin-right: 0px;
 }
 
 .mr-2 {
@@ -1167,6 +1154,10 @@ nav a {
   height: 6rem;
 }
 
+.h-32 {
+  height: 8rem;
+}
+
 .h-4 {
   height: 1rem;
 }
@@ -1187,14 +1178,6 @@ nav a {
   height: 16rem;
 }
 
-.h-full {
-  height: 100%;
-}
-
-.h-screen {
-  height: 100vh;
-}
-
 .min-h-\[60vh\] {
   min-height: 60vh;
 }
@@ -1209,10 +1192,6 @@ nav a {
 
 .w-16 {
   width: 4rem;
-}
-
-.w-2\/3 {
-  width: 66.666667%;
 }
 
 .w-4 {
@@ -2134,29 +2113,14 @@ nav a {
   border-bottom-left-radius: 0.25rem;
 }
 
-.rounded-l-lg {
-  border-top-left-radius: 0.5rem;
-  border-bottom-left-radius: 0.5rem;
-}
-
 .rounded-r {
   border-top-right-radius: 0.25rem;
   border-bottom-right-radius: 0.25rem;
 }
 
-.rounded-r-lg {
-  border-top-right-radius: 0.5rem;
-  border-bottom-right-radius: 0.5rem;
-}
-
 .rounded-t {
   border-top-left-radius: 0.25rem;
   border-top-right-radius: 0.25rem;
-}
-
-.rounded-t-lg {
-  border-top-left-radius: 0.5rem;
-  border-top-right-radius: 0.5rem;
 }
 
 .rounded-bl {
@@ -2307,11 +2271,6 @@ nav a {
   border-color: rgb(250 204 21 / var(--tw-border-opacity));
 }
 
-.border-yellow-500 {
-  --tw-border-opacity: 1;
-  border-color: rgb(234 179 8 / var(--tw-border-opacity));
-}
-
 .bg-\[rgb\(255\2c 0\2c 0\)\] {
   --tw-bg-opacity: 1;
   background-color: rgb(255 0 0 / var(--tw-bg-opacity));
@@ -2355,11 +2314,6 @@ nav a {
 .bg-gray-500 {
   --tw-bg-opacity: 1;
   background-color: rgb(107 114 128 / var(--tw-bg-opacity));
-}
-
-.bg-gray-600 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(75 85 99 / var(--tw-bg-opacity));
 }
 
 .bg-gray-800 {
@@ -2407,11 +2361,6 @@ nav a {
   background-color: rgb(255 237 213 / var(--tw-bg-opacity));
 }
 
-.bg-orange-200 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 215 170 / var(--tw-bg-opacity));
-}
-
 .bg-pink-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(252 231 243 / var(--tw-bg-opacity));
@@ -2442,11 +2391,6 @@ nav a {
   background-color: rgb(254 242 242 / var(--tw-bg-opacity));
 }
 
-.bg-siteBackground {
-  --tw-bg-opacity: 1;
-  background-color: rgb(74 74 74 / var(--tw-bg-opacity));
-}
-
 .bg-teal-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(204 251 241 / var(--tw-bg-opacity));
@@ -2455,11 +2399,6 @@ nav a {
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
-}
-
-.bg-yellow-400 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(250 204 21 / var(--tw-bg-opacity));
 }
 
 .bg-yellow-50 {
@@ -2616,11 +2555,6 @@ nav a {
   padding: 2rem;
 }
 
-.px-1 {
-  padding-left: 0.25rem;
-  padding-right: 0.25rem;
-}
-
 .px-2 {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
@@ -2636,19 +2570,9 @@ nav a {
   padding-right: 1rem;
 }
 
-.px-5 {
-  padding-left: 1.25rem;
-  padding-right: 1.25rem;
-}
-
 .px-6 {
   padding-left: 1.5rem;
   padding-right: 1.5rem;
-}
-
-.px-8 {
-  padding-left: 2rem;
-  padding-right: 2rem;
 }
 
 .py-1 {
@@ -2676,11 +2600,6 @@ nav a {
   padding-bottom: 0.75rem;
 }
 
-.py-5 {
-  padding-top: 1.25rem;
-  padding-bottom: 1.25rem;
-}
-
 .py-8 {
   padding-top: 2rem;
   padding-bottom: 2rem;
@@ -2690,16 +2609,8 @@ nav a {
   padding-bottom: 0.5rem;
 }
 
-.pb-3 {
-  padding-bottom: 0.75rem;
-}
-
 .pt-1 {
   padding-top: 0.25rem;
-}
-
-.pt-3 {
-  padding-top: 0.75rem;
 }
 
 .pt-8 {
@@ -2814,10 +2725,6 @@ nav a {
   font-weight: 700;
 }
 
-.font-light {
-  font-weight: 300;
-}
-
 .font-medium {
   font-weight: 500;
 }
@@ -2900,6 +2807,10 @@ nav a {
 
 .leading-relaxed {
   line-height: 1.625;
+}
+
+.leading-snug {
+  line-height: 1.375;
 }
 
 .tracking-widest {
@@ -3498,11 +3409,6 @@ nav a {
   font-weight: 700;
 }
 
-.hover\:text-black:hover {
-  --tw-text-opacity: 1;
-  color: rgb(0 0 0 / var(--tw-text-opacity));
-}
-
 .hover\:text-blue-600:hover {
   --tw-text-opacity: 1;
   color: rgb(37 99 235 / var(--tw-text-opacity));
@@ -3571,7 +3477,16 @@ nav a {
   text-align: center;
 }
 
+.group:hover .group-hover\:text-blue-600 {
+  --tw-text-opacity: 1;
+  color: rgb(37 99 235 / var(--tw-text-opacity));
+}
+
 @media (min-width: 640px) {
+  .sm\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .sm\:flex-row {
     flex-direction: row;
   }
@@ -3592,14 +3507,6 @@ nav a {
     margin-right: 1.5rem;
   }
 
-  .md\:ml-8 {
-    margin-left: 2rem;
-  }
-
-  .md\:inline {
-    display: inline;
-  }
-
   .md\:flex {
     display: flex;
   }
@@ -3614,10 +3521,6 @@ nav a {
 
   .md\:h-96 {
     height: 24rem;
-  }
-
-  .md\:w-2\/3 {
-    width: 66.666667%;
   }
 
   .md\:w-48 {
@@ -3666,16 +3569,6 @@ nav a {
     padding: 2rem;
   }
 
-  .md\:px-10 {
-    padding-left: 2.5rem;
-    padding-right: 2.5rem;
-  }
-
-  .md\:px-5 {
-    padding-left: 1.25rem;
-    padding-right: 1.25rem;
-  }
-
   .md\:py-16 {
     padding-top: 4rem;
     padding-bottom: 4rem;
@@ -3684,11 +3577,6 @@ nav a {
   .md\:py-20 {
     padding-top: 5rem;
     padding-bottom: 5rem;
-  }
-
-  .md\:py-5 {
-    padding-top: 1.25rem;
-    padding-bottom: 1.25rem;
   }
 
   .md\:text-left {
@@ -3712,10 +3600,6 @@ nav a {
 }
 
 @media (min-width: 1024px) {
-  .lg\:inline {
-    display: inline;
-  }
-
   .lg\:grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,28 +3,41 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Spicer Matthews Personal Site</title>
-  <meta name="description" content="" />
+
+  
+  <title>Spicer Matthews — Software Developer &amp; Options Trader</title>
+  <meta name="description" content="Spicer Matthews is a software developer, entrepreneur, and options trader in Newberg, Oregon. I write about AI-first development with Claude Code, building products, and trading options." />
+  <meta name="keywords" content="Spicer Matthews, software developer, options trader, entrepreneur, AI-first development, Claude Code, Newberg Oregon" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/" />
+
   <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
 
   
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="Spicer Matthews Personal Site" />
-  <meta property="og:description" content="" />
+  <meta property="og:title" content="Spicer Matthews — Software Developer &amp; Options Trader" />
+  <meta property="og:description" content="Spicer Matthews is a software developer, entrepreneur, and options trader in Newberg, Oregon. I write about AI-first development with Claude Code, building products, and trading options." />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/" />
-  <meta property="og:locale" content="en" />
-
-  
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:alt" content="Spicer Matthews — Software Developer &amp; Options Trader" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-  
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="" />
+  <meta name="twitter:title" content="Spicer Matthews — Software Developer &amp; Options Trader" />
+  <meta name="twitter:description" content="Spicer Matthews is a software developer, entrepreneur, and options trader in Newberg, Oregon. I write about AI-first development with Claude Code, building products, and trading options." />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@id":"https://spicermatthews.com/#person","@type":"Person","homeLocation":{"@type":"Place","name":"Newberg, Oregon"},"image":"https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg","jobTitle":"Software Developer \u0026 Entrepreneur","name":"Spicer Matthews","sameAs":["https://twitter.com/spicermatthews","https://cloudmanic.com","https://matthews-etc.com"],"url":"https://spicermatthews.com/"},{"@id":"https://spicermatthews.com/#website","@type":"WebSite","description":"Spicer Matthews is a software developer, entrepreneur, and options trader in Newberg, Oregon — writing about AI-first development, building products, and options trading.","inLanguage":"en-US","name":"Spicer Matthews Personal Site","publisher":{"@id":"https://spicermatthews.com/#person"},"url":"https://spicermatthews.com/"}]}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">
@@ -151,7 +164,7 @@
             </a>
           </h3>
           
-          <p class="text-gray-600 line-clamp-3 my-0">I went full circle back to the terminal, but Vim never quite fit. So I vibe coded SpiceEdit — a mouse-first terminal code editor for engineers who live in tmux and SSH, without a four-thousand-line vimrc. One Go binary. MIT licensed. Free forever.</p>
+          <p class="text-gray-600 line-clamp-3 my-0">I vibe coded SpiceEdit, a mouse-first terminal code editor for AI-era devs who live in tmux and SSH. One Go binary, no vimrc, MIT licensed, free forever.</p>
           
         </div>
       </article>
@@ -170,7 +183,7 @@
             </a>
           </h3>
           
-          <p class="text-gray-600 line-clamp-3 my-0">For 15 years I had a CPA I trusted. She worked from home, we did almost everything by email, and tax season felt manageable. Since she retired I&#39;ve been trying to find that same relationship — digital-first, responsive, and organized — and I haven&#39;t. Here&#39;s what I&#39;m looking for.</p>
+          <p class="text-gray-600 line-clamp-3 my-0">For 15 years I had a digital-first CPA I trusted. Since she retired I can&#39;t find a responsive, organized replacement. Here&#39;s exactly what I&#39;m looking for.</p>
           
         </div>
       </article>
@@ -189,7 +202,7 @@
             </a>
           </h3>
           
-          <p class="text-gray-600 line-clamp-3 my-0">MCP servers flood your AI agent&#39;s context window with massive JSON payloads. A CLI gives it exactly what it needs. Here&#39;s why I built a full Tradier brokerage CLI in Go — and why CLIs are the better interface for AI-powered trading workflows.</p>
+          <p class="text-gray-600 line-clamp-3 my-0">I built a full Tradier brokerage CLI in Go so AI agents like Claude Code can trade without flooding the context window. Here is why CLIs beat MCP servers.</p>
           
         </div>
       </article>
@@ -208,7 +221,7 @@
             </a>
           </h3>
           
-          <p class="text-gray-600 line-clamp-3 my-0">I&#39;ve been living in the terminal with Claude Code, Neovim, and tmux. But sharing screenshots with an AI that lives in a terminal session? That was broken. So I vibe coded a macOS screenshot tool that uploads to S3 and gives me a direct URL. Problem solved.</p>
+          <p class="text-gray-600 line-clamp-3 my-0">Sharing screenshots with Claude Code over SSH was broken, so I vibe coded a macOS menu bar app that uploads to S3 and drops a direct image URL on my clipboard.</p>
           
         </div>
       </article>
@@ -227,7 +240,7 @@
             </a>
           </h3>
           
-          <p class="text-gray-600 line-clamp-3 my-0">I started my career in the late 90s doing everything in the terminal. Over 30 years I migrated to GUIs, web apps, and desktop tools. Now, thanks to Claude Code, Neovim, and tmux, I&#39;m back where I started — and it&#39;s never felt better.</p>
+          <p class="text-gray-600 line-clamp-3 my-0">After 30 years in GUIs, I&#39;m back in the terminal full-time with Claude Code, Neovim, and tmux. Here&#39;s my development workflow and why it feels like home.</p>
           
         </div>
       </article>
@@ -246,7 +259,7 @@
             </a>
           </h3>
           
-          <p class="text-gray-600 line-clamp-3 my-0">MCP servers flood your AI agent&#39;s context window. A CLI doesn&#39;t. I built Massive CLI — a command-line tool for the Massive financial data API — because a single binary that outputs clean tables or JSON is a better fit for both humans and AI agents.</p>
+          <p class="text-gray-600 line-clamp-3 my-0">MCP servers flood your AI agent&#39;s context window. So I built Massive CLI, a command-line tool for the Massive financial data API that outputs clean tables or JSON.</p>
           
         </div>
       </article>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>Spicer Matthews Personal Site</title>
+    <title>Spicer Matthews — Software Developer &amp; Options Trader on Spicer Matthews Personal Site</title>
     <link>https://spicermatthews.com/</link>
-    <description>Recent content on Spicer Matthews Personal Site</description>
+    <description>Recent content in Spicer Matthews — Software Developer &amp; Options Trader on Spicer Matthews Personal Site</description>
     <generator>Hugo</generator>
     <language>en-us</language>
     <lastBuildDate>Thu, 30 Apr 2026 12:00:00 -0700</lastBuildDate>
@@ -142,7 +142,7 @@
       <description>Have you ever noticed that when someone drinks too much, they become predictable? They might start talking louder or acting crazier than usual. It&#39;s as if the alcohol has unlocked a different side of their personality. Most people are pretty steady and predictable creatures when they&#39;re sober, but when they get drunk, all bets are off. The same can be said for the stock market. Sometimes, stocks in the stock market behave like they&#39;re drunk.</description>
     </item>
     <item>
-      <title>Am Over Vendors That Are Not Transparent in Pricing</title>
+      <title>I&#39;m Over Vendors That Aren&#39;t Transparent About Pricing</title>
       <link>https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/</link>
       <pubDate>Tue, 21 Apr 2020 20:18:58 -0700</pubDate>
       <guid>https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/</guid>

--- a/docs/projects/index.html
+++ b/docs/projects/index.html
@@ -3,28 +3,41 @@
 <html lang="en"><head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>Projects</title>
+
+  
+  <title>Projects | Spicer Matthews</title>
   <meta name="description" content="Software projects and ventures by Spicer Matthews" />
+  <meta name="keywords" content="Spicer Matthews, software developer, options trading, entrepreneur, AI-first development, Claude Code, Hugo static site, Newberg Oregon" />
+  <meta name="author" content="Spicer Matthews" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  <link rel="canonical" href="https://spicermatthews.com/projects/" />
+
   <link rel="shortcut icon" type="image/png" href="https://spicermatthews.com/images/favicon.ico" />
-  <link href="https://spicermatthews.com/css/build.css?v=e40562ba95" media="all" rel="stylesheet" />
+  <link href="https://spicermatthews.com/css/build.css?v=33f2b0ff8a" media="all" rel="stylesheet" />
+
+  
+  <link rel="alternate" type="application/rss+xml" title="Spicer Matthews Personal Site" href="https://spicermatthews.com/index.xml" />
 
   
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="Projects" />
+  <meta property="og:title" content="Projects | Spicer Matthews" />
   <meta property="og:description" content="Software projects and ventures by Spicer Matthews" />
   <meta property="og:site_name" content="Spicer Matthews Personal Site" />
   <meta property="og:url" content="https://spicermatthews.com/projects/" />
-  <meta property="og:locale" content="en" />
-
-  
-  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:secure_url" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
+  <meta property="og:image:alt" content="Projects" />
 
   
   <meta name="twitter:card" content="summary_large_image" />
-  
-  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Projects | Spicer Matthews" />
   <meta name="twitter:description" content="Software projects and ventures by Spicer Matthews" />
+  <meta name="twitter:site" content="@spicermatthews" />
+  <meta name="twitter:creator" content="@spicermatthews" />
+  <meta name="twitter:image" content="https://spicermatthews.com/images/spicer-matthews-wine-drinking.jpg" />
 
+  <meta name="theme-color" content="#2563eb" /><script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","description":"Software projects and ventures by Spicer Matthews","inLanguage":"en-US","isPartOf":{"@id":"https://spicermatthews.com/#website"},"name":"Projects","url":"https://spicermatthews.com/projects/"}</script><link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>
 <body class="bg-gray-50 min-h-screen font-sans antialiased">

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,38 @@
+# robots.txt for spicermatthews.com
+# Rendered by Hugo (enableRobotsTXT = true). All crawlers welcome.
+
+User-agent: *
+Allow: /
+
+# AI / LLM crawlers are explicitly welcomed — we want to be cited by AI search.
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+Sitemap: https://spicermatthews.com/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -4,82 +4,136 @@
   <url>
     <loc>https://spicermatthews.com/blog/</loc>
     <lastmod>2026-04-30T12:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/introducing-spice-edit/</loc>
     <lastmod>2026-04-30T12:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/</loc>
     <lastmod>2026-04-30T12:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/looking-for-a-new-cpa/</loc>
     <lastmod>2026-04-20T08:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/i-built-a-tradier-cli-because-ai-agents-deserve-better-tools/</loc>
     <lastmod>2026-03-18T08:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/i-vibe-coded-a-screenshot-tool-because-claude-code-needed-one/</loc>
     <lastmod>2026-02-24T12:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/full-circle-back-to-the-terminal/</loc>
     <lastmod>2026-02-19T12:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/why-i-built-a-cli-for-massive-financial-data/</loc>
     <lastmod>2026-02-16T10:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/just-do-stuff/</loc>
     <lastmod>2026-02-03T12:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/i-built-a-personal-ai-assistant-that-lives-in-slack/</loc>
     <lastmod>2026-01-30T10:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/why-100-customers-at-200-beats-1000-at-20/</loc>
     <lastmod>2026-01-19T10:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/you-dont-lack-time-you-lack-a-system/</loc>
     <lastmod>2026-01-13T10:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/my-new-ai-first-development-workflow-github-issues/</loc>
     <lastmod>2025-12-29T10:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/remodeling-my-home-proved-one-thing-we-need-robots-to-build-houses/</loc>
     <lastmod>2025-12-02T10:00:00-08:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/how-i-learned-to-spot-inflated-bids-and-what-you-can-do-too/</loc>
     <lastmod>2025-10-15T10:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/the-ai-side-hustle-revolution-turning-niche-ideas-into-income/</loc>
     <lastmod>2025-06-06T10:00:00-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/reimagining-real-estate-a-call-for-excellence-over-exclusivity/</loc>
     <lastmod>2024-03-26T12:18:58-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/streamlining-code-reviews-maximize-efficiency-and-effectiveness/</loc>
     <lastmod>2023-03-30T20:18:58-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/nitpicking-code-quality-a-necessary-evil-or-a-harmful-habit/</loc>
     <lastmod>2023-03-22T13:18:58-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/prioritizing-tdd-friendly-languages-and-frameworks/</loc>
     <lastmod>2023-03-18T20:18:58-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/the-stock-market-is-a-drunken-idiot-you-should-profit-from-it/</loc>
     <lastmod>2023-02-24T20:18:58-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/am-over-vendors-that-are-not-transparent-in-pricing/</loc>
     <lastmod>2020-04-21T20:18:58-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/spicers-rules-on-how-and-when-to-test-your-code/</loc>
     <lastmod>2019-09-15T12:18:58-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/using-hugo-with-google-docs/</loc>
     <lastmod>2019-08-01T12:18:58-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/delighting-customers-with-airbnb/</loc>
     <lastmod>2019-07-30T12:18:58-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/blog/hello-world-my-new-blog-hugo-tailwind-css-and-more/</loc>
     <lastmod>2019-07-17T19:02:38-07:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url><url>
     <loc>https://spicermatthews.com/projects/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -66,6 +66,37 @@
         </a>
       </div>
     </div>
+
+    <!-- Related Posts (internal linking). Prefer curated `related` slugs from
+         frontmatter; fall back to Hugo's keyword/recency related content. -->
+    {{- $related := slice -}}
+    {{- with .Params.related }}
+      {{- range . }}
+        {{- with $.Site.GetPage (printf "/blog/%s" .) }}
+          {{- $related = $related | append . }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- if not $related }}
+      {{- $blog := where .Site.RegularPages "Section" "blog" -}}
+      {{- $related = first 3 ($blog.Related .) -}}
+    {{- end }}
+    {{- with $related }}
+    <div class="mt-12 pt-8 border-t">
+      <h2 class="text-xl font-semibold text-gray-900 mb-6">Related Posts</h2>
+      <div class="grid gap-6 sm:grid-cols-3">
+        {{- range . }}
+        <a href="{{ .Permalink }}" class="block no-underline group">
+          {{- if .Params.og_image }}
+          <img src="{{ .Params.og_image }}" alt="{{ .Title }}" class="w-full h-32 object-cover rounded-lg mb-3" />
+          {{- end }}
+          <span class="block text-gray-900 font-medium leading-snug group-hover:text-blue-600">{{ .Title }}</span>
+          <time class="block text-sm text-gray-500 mt-1">{{ .Date.Format "January 2, 2006" }}</time>
+        </a>
+        {{- end }}
+      </div>
+    </div>
+    {{- end }}
   </div>
 </article>
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,28 +1,79 @@
+{{/*
+  head.html - Document head: SEO meta, canonical, Open Graph, Twitter cards, and JSON-LD.
+  Copyright 2026 Spicer Matthews
+  Date: 2026-05-31
+*/}}
+{{- $brand := .Site.Params.brand | default .Site.Title -}}
+{{- $desc := or .Description .Site.Params.description -}}
+{{- $ogImage := .Params.og_image | default .Site.Params.og_image -}}
+{{- $ogImageAbs := $ogImage | absURL -}}
+{{- $isArticle := and .IsPage (eq .Section "blog") -}}
+{{- $fullTitle := cond .IsHome .Title (printf "%s | %s" .Title $brand) -}}
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <title>{{ .Title }}</title>
-  <meta name="description" content="{{ .Description }}" />
+
+  <!-- Primary SEO meta -->
+  <title>{{ $fullTitle }}</title>
+  <meta name="description" content="{{ $desc }}" />
+  {{- $keywords := .Keywords }}{{ if not $keywords }}{{ $keywords = .Site.Params.keywords }}{{ end }}
+  {{- with $keywords }}
+  <meta name="keywords" content="{{ delimit . ", " }}" />
+  {{- end }}
+  <meta name="author" content="{{ .Site.Params.author | default $brand }}" />
+  {{- if eq .Kind "404" }}
+  <meta name="robots" content="noindex, follow" />
+  {{- else }}
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+  {{- end }}
+  <link rel="canonical" href="{{ .Permalink }}" />
+
   <link rel="shortcut icon" type="image/png" href="{{ .Site.BaseURL }}images/favicon.ico" />
   <link href="{{ .Site.BaseURL }}css/build.css?v={{ slicestr (readFile "static/css/build.css" | md5) 0 10 }}" media="all" rel="stylesheet" />
 
-  <!-- open graph -->
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="{{ .Title }}" />
-  <meta property="og:description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Site.Params.description }}{{ end }}" />
+  <!-- RSS feed -->
+  {{- with .Site.Home.OutputFormats.Get "rss" }}
+  <link rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" href="{{ .Permalink }}" />
+  {{- end }}
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="{{ cond $isArticle "article" "website" }}" />
+  <meta property="og:title" content="{{ $fullTitle }}" />
+  <meta property="og:description" content="{{ $desc }}" />
   <meta property="og:site_name" content="{{ .Site.Title }}" />
   <meta property="og:url" content="{{ .Permalink }}" />
-  <meta property="og:locale" content="en" />
+  <meta property="og:locale" content="{{ .Site.Params.locale | default "en_US" }}" />
+  {{- with $ogImageAbs }}
+  <meta property="og:image" content="{{ . }}" />
+  <meta property="og:image:secure_url" content="{{ . }}" />
+  <meta property="og:image:alt" content="{{ $.Title }}" />
+  {{- end }}
+  {{- if $isArticle }}
+  <meta property="article:published_time" content="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}" />
+  <meta property="article:modified_time" content="{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}" />
+  <meta property="article:author" content="{{ .Site.Params.author | default $brand }}" />
+  <meta property="article:section" content="Blog" />
+  {{- range .Keywords }}
+  <meta property="article:tag" content="{{ . }}" />
+  {{- end }}
+  {{- end }}
 
-  {{ if $.Param "og_image" }} <meta property="og:image" content="{{ $.Param "og_image" | absURL }}" /> <meta property="og:image:secure_url" content="{{ $.Param "og_image" | absURL
-  }}" /> {{ end }}
-  <meta property="og:type" content="website" />
+  <!-- Twitter card -->
+  <meta name="twitter:card" content="{{ cond (ne $ogImage "") "summary_large_image" "summary" }}" />
+  <meta name="twitter:title" content="{{ $fullTitle }}" />
+  <meta name="twitter:description" content="{{ $desc }}" />
+  {{- with .Site.Params.twitter }}
+  <meta name="twitter:site" content="@{{ . }}" />
+  <meta name="twitter:creator" content="@{{ . }}" />
+  {{- end }}
+  {{- with $ogImageAbs }}
+  <meta name="twitter:image" content="{{ . }}" />
+  {{- end }}
 
-  <!-- twitter -->
-  <meta name="twitter:card" content="summary_large_image" />
-  {{ if $.Param "og_image" }} <meta name="twitter:image:src" content="{{ $.Param "og_image" | absURL }}" /> {{ end }}
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Site.Params.description }}{{ end }}" />
+  <meta name="theme-color" content="#2563eb" />
 
+  {{- partial "schema.html" . -}}
+
+  <link rel="preconnect" href="https://plausible.io" />
   <script defer data-domain="spicermatthews.com" src="https://plausible.io/js/script.js"></script>
 </head>

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -1,0 +1,77 @@
+{{/*
+  schema.html - JSON-LD structured data (schema.org) for richer search results and
+  better understanding by AI / LLM crawlers. Emits a Person + WebSite graph on the
+  homepage, BlogPosting + BreadcrumbList on blog posts, and a WebPage elsewhere.
+  Copyright 2026 Spicer Matthews
+  Date: 2026-05-31
+*/}}
+{{- $site := .Site -}}
+{{- $baseURL := $site.BaseURL -}}
+{{- $authorName := $site.Params.author | default "Spicer Matthews" -}}
+{{- $authorImg := "images/spicer-matthews-wine-drinking.jpg" | absURL -}}
+{{- $sameAs := slice "https://twitter.com/spicermatthews" "https://cloudmanic.com" "https://matthews-etc.com" -}}
+{{- $person := dict
+    "@type" "Person"
+    "@id" (printf "%s#person" $baseURL)
+    "name" $authorName
+    "url" $baseURL
+    "image" $authorImg
+    "jobTitle" "Software Developer & Entrepreneur"
+    "homeLocation" (dict "@type" "Place" "name" "Newberg, Oregon")
+    "sameAs" $sameAs
+-}}
+{{- $website := dict
+    "@type" "WebSite"
+    "@id" (printf "%s#website" $baseURL)
+    "url" $baseURL
+    "name" $site.Title
+    "description" $site.Params.description
+    "inLanguage" "en-US"
+    "publisher" (dict "@id" (printf "%s#person" $baseURL))
+-}}
+{{- if .IsHome -}}
+{{- $graph := dict "@context" "https://schema.org" "@graph" (slice $person $website) -}}
+<script type="application/ld+json">{{ $graph | jsonify | safeJS }}</script>
+{{- else if and .IsPage (eq .Section "blog") -}}
+{{- $ogImage := .Params.og_image | default $site.Params.og_image -}}
+{{- $img := $ogImage | absURL -}}
+{{- $desc := or .Description $site.Params.description -}}
+{{- $posting := dict
+    "@context" "https://schema.org"
+    "@type" "BlogPosting"
+    "mainEntityOfPage" (dict "@type" "WebPage" "@id" .Permalink)
+    "headline" .Title
+    "name" .Title
+    "description" $desc
+    "image" (slice $img)
+    "datePublished" (.Date.Format "2006-01-02T15:04:05Z07:00")
+    "dateModified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
+    "author" $person
+    "publisher" $person
+    "url" .Permalink
+    "inLanguage" "en-US"
+    "wordCount" .WordCount
+    "articleSection" "Blog"
+    "keywords" (delimit .Keywords ", ")
+-}}
+<script type="application/ld+json">{{ $posting | jsonify | safeJS }}</script>
+{{- $crumbs := slice
+    (dict "@type" "ListItem" "position" 1 "name" "Home" "item" $baseURL)
+    (dict "@type" "ListItem" "position" 2 "name" "Blog" "item" (printf "%sblog/" $baseURL))
+    (dict "@type" "ListItem" "position" 3 "name" .Title "item" .Permalink)
+-}}
+{{- $breadcrumb := dict "@context" "https://schema.org" "@type" "BreadcrumbList" "itemListElement" $crumbs -}}
+<script type="application/ld+json">{{ $breadcrumb | jsonify | safeJS }}</script>
+{{- else -}}
+{{- $desc := or .Description $site.Params.description -}}
+{{- $webpage := dict
+    "@context" "https://schema.org"
+    "@type" "WebPage"
+    "url" .Permalink
+    "name" .Title
+    "description" $desc
+    "isPartOf" (dict "@id" (printf "%s#website" $baseURL))
+    "inLanguage" "en-US"
+-}}
+<script type="application/ld+json">{{ $webpage | jsonify | safeJS }}</script>
+{{- end -}}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,38 @@
+# robots.txt for spicermatthews.com
+# Rendered by Hugo (enableRobotsTXT = true). All crawlers welcome.
+
+User-agent: *
+Allow: /
+
+# AI / LLM crawlers are explicitly welcomed — we want to be cited by AI search.
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+Sitemap: {{ "sitemap.xml" | absURL }}

--- a/static/css/build.css
+++ b/static/css/build.css
@@ -960,11 +960,6 @@ nav a {
   margin-bottom: 1rem;
 }
 
-.my-5 {
-  margin-top: 1.25rem;
-  margin-bottom: 1.25rem;
-}
-
 .my-6 {
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
@@ -1005,14 +1000,6 @@ nav a {
 
 .ml-4 {
   margin-left: 1rem;
-}
-
-.ml-5 {
-  margin-left: 1.25rem;
-}
-
-.mr-0 {
-  margin-right: 0px;
 }
 
 .mr-2 {
@@ -1167,6 +1154,10 @@ nav a {
   height: 6rem;
 }
 
+.h-32 {
+  height: 8rem;
+}
+
 .h-4 {
   height: 1rem;
 }
@@ -1187,14 +1178,6 @@ nav a {
   height: 16rem;
 }
 
-.h-full {
-  height: 100%;
-}
-
-.h-screen {
-  height: 100vh;
-}
-
 .min-h-\[60vh\] {
   min-height: 60vh;
 }
@@ -1209,10 +1192,6 @@ nav a {
 
 .w-16 {
   width: 4rem;
-}
-
-.w-2\/3 {
-  width: 66.666667%;
 }
 
 .w-4 {
@@ -2134,29 +2113,14 @@ nav a {
   border-bottom-left-radius: 0.25rem;
 }
 
-.rounded-l-lg {
-  border-top-left-radius: 0.5rem;
-  border-bottom-left-radius: 0.5rem;
-}
-
 .rounded-r {
   border-top-right-radius: 0.25rem;
   border-bottom-right-radius: 0.25rem;
 }
 
-.rounded-r-lg {
-  border-top-right-radius: 0.5rem;
-  border-bottom-right-radius: 0.5rem;
-}
-
 .rounded-t {
   border-top-left-radius: 0.25rem;
   border-top-right-radius: 0.25rem;
-}
-
-.rounded-t-lg {
-  border-top-left-radius: 0.5rem;
-  border-top-right-radius: 0.5rem;
 }
 
 .rounded-bl {
@@ -2307,11 +2271,6 @@ nav a {
   border-color: rgb(250 204 21 / var(--tw-border-opacity));
 }
 
-.border-yellow-500 {
-  --tw-border-opacity: 1;
-  border-color: rgb(234 179 8 / var(--tw-border-opacity));
-}
-
 .bg-\[rgb\(255\2c 0\2c 0\)\] {
   --tw-bg-opacity: 1;
   background-color: rgb(255 0 0 / var(--tw-bg-opacity));
@@ -2355,11 +2314,6 @@ nav a {
 .bg-gray-500 {
   --tw-bg-opacity: 1;
   background-color: rgb(107 114 128 / var(--tw-bg-opacity));
-}
-
-.bg-gray-600 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(75 85 99 / var(--tw-bg-opacity));
 }
 
 .bg-gray-800 {
@@ -2407,11 +2361,6 @@ nav a {
   background-color: rgb(255 237 213 / var(--tw-bg-opacity));
 }
 
-.bg-orange-200 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 215 170 / var(--tw-bg-opacity));
-}
-
 .bg-pink-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(252 231 243 / var(--tw-bg-opacity));
@@ -2442,11 +2391,6 @@ nav a {
   background-color: rgb(254 242 242 / var(--tw-bg-opacity));
 }
 
-.bg-siteBackground {
-  --tw-bg-opacity: 1;
-  background-color: rgb(74 74 74 / var(--tw-bg-opacity));
-}
-
 .bg-teal-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(204 251 241 / var(--tw-bg-opacity));
@@ -2455,11 +2399,6 @@ nav a {
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
-}
-
-.bg-yellow-400 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(250 204 21 / var(--tw-bg-opacity));
 }
 
 .bg-yellow-50 {
@@ -2616,11 +2555,6 @@ nav a {
   padding: 2rem;
 }
 
-.px-1 {
-  padding-left: 0.25rem;
-  padding-right: 0.25rem;
-}
-
 .px-2 {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
@@ -2636,19 +2570,9 @@ nav a {
   padding-right: 1rem;
 }
 
-.px-5 {
-  padding-left: 1.25rem;
-  padding-right: 1.25rem;
-}
-
 .px-6 {
   padding-left: 1.5rem;
   padding-right: 1.5rem;
-}
-
-.px-8 {
-  padding-left: 2rem;
-  padding-right: 2rem;
 }
 
 .py-1 {
@@ -2676,11 +2600,6 @@ nav a {
   padding-bottom: 0.75rem;
 }
 
-.py-5 {
-  padding-top: 1.25rem;
-  padding-bottom: 1.25rem;
-}
-
 .py-8 {
   padding-top: 2rem;
   padding-bottom: 2rem;
@@ -2690,16 +2609,8 @@ nav a {
   padding-bottom: 0.5rem;
 }
 
-.pb-3 {
-  padding-bottom: 0.75rem;
-}
-
 .pt-1 {
   padding-top: 0.25rem;
-}
-
-.pt-3 {
-  padding-top: 0.75rem;
 }
 
 .pt-8 {
@@ -2814,10 +2725,6 @@ nav a {
   font-weight: 700;
 }
 
-.font-light {
-  font-weight: 300;
-}
-
 .font-medium {
   font-weight: 500;
 }
@@ -2900,6 +2807,10 @@ nav a {
 
 .leading-relaxed {
   line-height: 1.625;
+}
+
+.leading-snug {
+  line-height: 1.375;
 }
 
 .tracking-widest {
@@ -3498,11 +3409,6 @@ nav a {
   font-weight: 700;
 }
 
-.hover\:text-black:hover {
-  --tw-text-opacity: 1;
-  color: rgb(0 0 0 / var(--tw-text-opacity));
-}
-
 .hover\:text-blue-600:hover {
   --tw-text-opacity: 1;
   color: rgb(37 99 235 / var(--tw-text-opacity));
@@ -3571,7 +3477,16 @@ nav a {
   text-align: center;
 }
 
+.group:hover .group-hover\:text-blue-600 {
+  --tw-text-opacity: 1;
+  color: rgb(37 99 235 / var(--tw-text-opacity));
+}
+
 @media (min-width: 640px) {
+  .sm\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .sm\:flex-row {
     flex-direction: row;
   }
@@ -3592,14 +3507,6 @@ nav a {
     margin-right: 1.5rem;
   }
 
-  .md\:ml-8 {
-    margin-left: 2rem;
-  }
-
-  .md\:inline {
-    display: inline;
-  }
-
   .md\:flex {
     display: flex;
   }
@@ -3614,10 +3521,6 @@ nav a {
 
   .md\:h-96 {
     height: 24rem;
-  }
-
-  .md\:w-2\/3 {
-    width: 66.666667%;
   }
 
   .md\:w-48 {
@@ -3666,16 +3569,6 @@ nav a {
     padding: 2rem;
   }
 
-  .md\:px-10 {
-    padding-left: 2.5rem;
-    padding-right: 2.5rem;
-  }
-
-  .md\:px-5 {
-    padding-left: 1.25rem;
-    padding-right: 1.25rem;
-  }
-
   .md\:py-16 {
     padding-top: 4rem;
     padding-bottom: 4rem;
@@ -3684,11 +3577,6 @@ nav a {
   .md\:py-20 {
     padding-top: 5rem;
     padding-bottom: 5rem;
-  }
-
-  .md\:py-5 {
-    padding-top: 1.25rem;
-    padding-bottom: 1.25rem;
   }
 
   .md\:text-left {
@@ -3712,10 +3600,6 @@ nav a {
 }
 
 @media (min-width: 1024px) {
-  .lg\:inline {
-    display: inline;
-  }
-
   .lg\:grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }


### PR DESCRIPTION
Closes #15

A full, multi-agent SEO audit and overhaul of the site — both **technical/template SEO** and **per-post content SEO**. 24 independent agents each reviewed one blog post for keywords, meta, titles, and structure; I implemented the technical foundation centrally and applied each agent's recommendations.

## What was broken before
- ❌ **No canonical tags** anywhere
- ❌ **No structured data (JSON-LD)** — search engines and LLMs had no machine-readable understanding of the content
- ❌ **Broken Twitter cards** — every page declared `summary_large_image` then immediately overrode it with `summary`, so rich image previews never worked
- ❌ **`og:type` always `website`** (even on articles), duplicated, and **no article timestamps**
- ❌ **`<title>` had no brand** and the OG description fallback was empty (`[params]` didn't exist)
- ❌ **No `robots.txt`**, no RSS `<link>` in `<head>`, no `meta keywords`/`author`
- ❌ **2 posts had empty meta descriptions**; **0 posts had keywords**; no internal linking between posts
- ⚠️ A grammatically broken post title (“Am Over Vendors…”) and a `className=` (React leftover) bug breaking blockquote styling in 3 posts

## What this PR does

### Technical SEO (templates + config)
- **`head.html`** — canonical tags, brand-suffixed `<title>` template, `meta` keywords/author/robots (`max-image-preview:large`), RSS `<link>`, `theme-color`; **fixed Open Graph** (`og:type=article` + `article:published_time`/`modified_time`/`tag` on posts) and a **single correct Twitter card** (title, `@spicermatthews` site/creator, image with default fallback).
- **`schema.html`** *(new)* — JSON-LD: **Person + WebSite** graph on the homepage, **BlogPosting + BreadcrumbList** on every post, **WebPage** elsewhere.
- **`config.toml`** — adds `[params]` (description, author, default `og_image`, twitter, keywords) so fallbacks resolve; enables `robots.txt`; adds sitemap defaults, a full RSS feed, and `[related]` config.
- **`layouts/robots.txt`** *(new)* — allows all crawlers, **explicitly welcomes AI/LLM bots** (GPTBot, ChatGPT-User, ClaudeBot, PerplexityBot, Google-Extended, CCBot, Applebot-Extended…), and points to the sitemap — directly targeting the LLM-traffic goal.
- **`content/_index.md` + `content/blog/_index.md`** *(new)* — real SEO titles/descriptions/keywords for the homepage and blog index.
- **`blog/single.html`** — a **Related Posts** section for internal linking.

### Per-post content SEO (all 24 posts)
- **Rewrote every meta description** (including the 2 empty ones) to a compelling 120–160 chars in Spicer's voice.
- **Added a focused keyword set** (primary + long-tail) to each post.
- **Added curated, topically-relevant internal links** (`related` frontmatter) to each post — builds topical authority and keeps readers on-site.
- **Fixed the broken title** → “I'm Over Vendors That Aren't Transparent About Pricing”.
- **Fixed `className=` → `class=`** in 3 posts so blockquote styling actually renders.

## Validation
Built with Hugo and programmatically verified across all 24 posts:
- ✅ 24/24 valid `BlogPosting` + `BreadcrumbList` JSON-LD (parses as JSON)
- ✅ 24/24 canonical tags, `og:type=article`, `meta keywords`, and Related Posts
- ✅ Homepage Person+WebSite graph, default social image, branded title
- ✅ `robots.txt` generated with sitemap; `sitemap.xml` well-formed; RSS includes all 24 posts
- ✅ Clean build, no Hugo warnings (also fixed a pre-existing `disableKinds` deprecation)

## Expected outcome
These are the standard, high-confidence SEO foundations — the gains compound as crawlers re-index over the weeks after merge:
- **Rich results & richer SERP listings:** valid Article/Breadcrumb structured data + accurate meta descriptions typically lift **organic click-through rate** on existing impressions (commonly a 5–15% CTR improvement once Google re-crawls).
- **Correct social/Twitter cards** mean shared links now render large image previews → more referral clicks per share.
- **LLM/AI citations:** clean JSON-LD, a full RSS feed, and an AI-crawler-friendly `robots.txt` make the site far easier for ChatGPT/Claude/Perplexity to parse and cite.
- **Topical authority & dwell time:** keyword-targeted descriptions + internal "Related Posts" linking help Google understand topic clusters (terminal/AI-dev tooling, options trading, construction/pricing, indie SaaS) and should improve rankings for long-tail queries over time.

Exact traffic numbers depend on indexing and competition, but every "basics in place" item from the issue (sitemaps, titles, canonicals, keywords, descriptions, structured data) is now done correctly.

## Notes
- The per-post agents also flagged that several older posts lack `<h2>` subheadings (they're single blocks of `<p>`). I left the prose untouched to preserve voice; adding subheadings is an easy, high-value follow-up if desired.